### PR TITLE
Typo fix

### DIFF
--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -16,7 +16,7 @@ function tell {
       h) _show_manual_for "tell";;
 
       m) # Set email of the git current user:
-        email=$(git config user.email) || _abort "'git congig user.email' is not set."
+        email=$(git config user.email) || _abort "'git config user.email' is not set."
       ;;
 
       d) homedir=$OPTARG;;


### PR DESCRIPTION
Typo fix from `git congig user.email` to `git config user.email`