### PR TITLE
Satisfy mktemp filename requirements

### DIFF
--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -13,6 +13,6 @@ function __delete_line_osx {
 
 function __temp_file_osx {
   : "${TMPDIR:=/tmp}"
-  local filename=$(mktemp -t _gitsecrets_ )
+  local filename=$(mktemp -t _gitsecrets_XXX )
   echo "$filename";
 }


### PR DESCRIPTION
According to http://www.gnu.org/software/autogen/mktemp.html doc
the temp filename should contain at least three X characters.