### PR TITLE
build-deb target: Create man dirs with execute permissions

### DIFF
--- a/utils/build-deb.sh
+++ b/utils/build-deb.sh
@@ -24,8 +24,8 @@ mkdir -p "$SCRIPT_DEST_DIR"
 
 # Coping the files inside the build folder:
 install -D -T -b -m "$EXEC_PEM" -T "git-secret" "${SCRIPT_DEST_DIR}/usr/bin/git-secret"
-install -m "$READ_PEM" -d "${SCRIPT_DEST_DIR}/usr/share/man/man1"
-install -m "$READ_PEM" -d "${SCRIPT_DEST_DIR}/usr/share/man/man7"
+install -m "$EXEC_PEM" -d "${SCRIPT_DEST_DIR}/usr/share/man/man1"
+install -m "$EXEC_PEM" -d "${SCRIPT_DEST_DIR}/usr/share/man/man7"
 for file in man/man1/* ; do
  if [[ "$file" == *.ronn ]]; then
    continue


### PR DESCRIPTION
The `make build-deb` target currently gives the following error on Ubuntu 14.04:

    $ make build-deb
    make[1]: Entering directory `/home/fboender/Projects/flusso/git-secret'
    make[1]: Leaving directory `/home/fboender/Projects/flusso/git-secret'
    install: cannot create directory /home/fboender/debbuild-git-secret/installroot/usr/share/man/man1: Permission denied
    make: *** [build-deb] Error 1

The man/* directories are created with permissions 644, but they should be 755. This commit fixes that issue.
