### PR TITLE
Allow git-secret to run from any directory in the work tree

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -142,6 +142,12 @@ function _add_ignored_file {
 }
 
 
+function _is_inside_git_tree {
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1
+    echo $?
+}
+
+
 # Logic :
 
 function _abort {

--- a/src/main.sh
+++ b/src/main.sh
@@ -4,7 +4,9 @@ set -e
 
 function _check_setup {
   # Checking git and secret-plugin setup:
-  if [[ ! -d ".git" ]] || [[ ! -d ".git/hooks" ]]; then
+  local is_tree
+  is_tree=$(_is_inside_git_tree)
+  if [[ $is_tree != "0" ]]; then
     _abort "repository is broken. try running 'git init' or 'git clone'."
   fi
 


### PR DESCRIPTION
Hi, this allows git-secret to work from any working directory in the git repository.  The .gitsecret directory remains in the working directory allowing users to have more than one .gitsecret in the repo.

This will result in a small change of behaviour.  If a user runs git-secret from the non-root of the repo' instead of exiting with 'not a repo' error it will exit with '.gitsecret directory not found'.