### PR TITLE
Add -d option to hide command to remove unencrypted files.

### DIFF
--- a/man/man1/git-secret-hide.1
+++ b/man/man1/git-secret-hide.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-HIDE" "1" "March 2016" "" ""
+.TH "GIT\-SECRET\-HIDE" "1" "February 2017" "" ""
 .
 .SH "NAME"
 \fBgit\-secret\-hide\fR \- encrypts all added files with the inner keyring\.
@@ -26,6 +26,7 @@ It is possible to modify the names of the encrypted files by setting \fBSECRETS_
 
 \-v  \- verbose, shows extra information\.
 \-c  \- deletes encrypted files before creating new ones\.
+\-d  \- deletes unencrypted files after encryption\.
 \-h  \- shows help\.
 .
 .fi

--- a/man/man1/git-secret-hide.1.ronn
+++ b/man/man1/git-secret-hide.1.ronn
@@ -16,6 +16,7 @@ It is possible to modify the names of the encrypted files by setting `SECRETS_EX
 
     -v  - verbose, shows extra information.
     -c  - deletes encrypted files before creating new ones.
+    -d  - deletes unencrypted files after encryption.
     -h  - shows help.
 
 

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -6,7 +6,7 @@ function _optional_clean {
   local clean=0
   local opt_string=''
 
-  while getopts 'cvh' opt; do
+  while getopts 'cdvh' opt; do
     case "$opt" in
       c) clean=1;;
 
@@ -27,6 +27,40 @@ function _optional_clean {
 }
 
 
+function _optional_delete {
+  local verbose=''
+  local delete=0
+
+  OPTIND=1
+
+  while getopts 'vd' opt; do
+    case "$opt" in
+      d) delete=1;;
+
+      v) verbose="v";;
+    esac
+  done
+
+  shift $((OPTIND-1))
+  [ "$1" = '--' ] && shift
+
+  if [[ $delete -eq 1 ]]; then
+    if [[ ! -z "$verbose" ]]; then
+      echo && echo 'removing unencrypted files:'
+    fi
+
+    while read -r line; do
+      find . -name "*$line" -type f -print0 | xargs -0 rm -f$verbose
+    done < "$SECRETS_DIR_PATHS_MAPPING"
+
+    if [[ ! -z "$verbose" ]]; then
+      echo
+    fi
+  fi
+
+}
+
+
 function hide {
   _optional_clean "$@"
 
@@ -44,6 +78,8 @@ function hide {
 
     counter=$((counter+1))
   done < "$SECRETS_DIR_PATHS_MAPPING"
+
+  _optional_delete "$@"
 
   echo "done. all $counter files are hidden."
 }

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -31,9 +31,16 @@ function teardown {
 }
 
 
-@test "run 'hide' with params" {
+@test "run 'hide' with -c param" {
   run git secret hide -v -c
   [ "$status" -eq 0 ]
+}
+
+
+@test "run 'hide' with -d param" {
+  run git secret hide -v -d
+  [ "$status" -eq 0 ]
+  [ ! -f "$FILE_TO_HIDE" ]
 }
 
 


### PR DESCRIPTION
This adds an option -d to the git secret hide command to remove the unencrypted files after encryption.  I often forget to git clean -fX and leave the unencrypted files in my repo.

Tested on Ubuntu 16.10 with bash (4.3.36) & zsh (5.2) & shellcheck (0.4.4).