### PR TITLE
Fix bug when passing more than one file to changes

### DIFF
--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -18,7 +18,7 @@ function changes {
   shift $((OPTIND-1))
   [ "$1" = '--' ] && shift
 
-  local filenames="$1"
+  local filenames="$@"
   if [[ -z "$filenames" ]]; then
     # Checking if no filenames are passed, show diff for all files.
     filenames=$(git secret list)

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -18,15 +18,15 @@ function changes {
   shift $((OPTIND-1))
   [ "$1" = '--' ] && shift
 
-  local filenames="$@"
-  if [[ -z "$filenames" ]]; then
+  local filenames=( "$@" )
+  if [[ ${#filenames[@]} -eq 0 ]]; then
     # Checking if no filenames are passed, show diff for all files.
-    filenames=$(git secret list)
+    filenames=( $(git secret list) )
   fi
 
   IFS='
   '
-  for filename in $filenames; do
+  for filename in "${filenames[@]}"; do
     local decrypted
     local content
     local diff_result

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -66,3 +66,21 @@ function teardown {
   [[ "$output" == *"changes in $SECOND_FILE_TO_HIDE"* ]]
   [[ "$output" == *"$second_file_to_hide"* ]]
 }
+
+@test "run 'changes' with multiple selected files changed" {
+  local password=$(test_user_password "$TEST_DEFAULT_USER")
+  local new_content="new content"
+  local second_new_content="something different"
+  echo "$new_content" >> "$FILE_TO_HIDE"
+  echo "$second_new_content" >> "$SECOND_FILE_TO_HIDE"
+
+  run git secret changes "$FILE_TO_HIDE" "$SECOND_FILE_TO_HIDE" -d "$TEST_GPG_HOMEDIR" -p "$password"
+  [ "$status" -eq 2 ]
+
+  # Testing that output has both filename and changes:
+  [[ "$output" == *"changes in $FILE_TO_HIDE"* ]]
+  [[ "$output" == *"$new_content"* ]]
+
+  [[ "$output" == *"changes in $SECOND_FILE_TO_HIDE"* ]]
+  [[ "$output" == *"$second_file_to_hide"* ]]
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
1. Make sure that you open your pull-request to the `develop` branch (master branch is protected, since some plugins use it when installed)
2. Make sure that tests pass
3. Make sure that your code has the same style

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
When passing more than one file to changes it only assumes the first one.


Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Operating system:** Mac OS 10.11.6

