### PR TITLE
Make hide -d work with secrets in subdirectories

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -282,7 +282,7 @@ function _find_and_clean {
   root=$(_get_git_root_path)
 
   # shellcheck disable=2086
-  find "$root" -name "$pattern" -type f -print0 | xargs -0 rm -f$verbose
+  find "$root" -path "$pattern" -type f -print0 | xargs -0 rm -f$verbose
 }
 
 

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -26,7 +26,7 @@ function _optional_delete {
 
     while read -r line; do
       # So the formating would not be repeated several times here:
-      _find_and_clean "$line" "$verbose"
+      _find_and_clean "*$line" "$verbose"
     done < "$path_mappings"
 
     if [[ ! -z "$verbose" ]]; then

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -97,6 +97,32 @@ function teardown {
 }
 
 
+@test "run 'hide' with '-d' and '-v' and files in subdirectories" {
+  # Preparations:
+  local root_dir='test_sub_dir'
+  mkdir -p "$root_dir"
+  local second_file="$root_dir/second_file.txt"
+  local second_content="some content"
+  set_state_secret_add "$second_file" "$second_content"
+
+  # Verify that the second file is there:
+  [ -f "$second_file" ]
+
+  # Now it should hide 2 files:
+  run git secret hide -v -d
+  [ "$status" -eq 0 ]
+
+  # File must be removed:
+  [ ! -f "$FILE_TO_HIDE" ]
+  [ ! -f "$second_file" ]
+
+  # It should be verbose:
+  [[ "$output" == *"removing unencrypted files"* ]]
+  [[ "$output" == *"$FILE_TO_HIDE"* ]]
+  [[ "$output" == *"$second_file"* ]]
+}
+
+
 @test "run 'hide' with multiple users" {
   install_fixture_key "$TEST_SECOND_USER"
   set_state_secret_tell "$TEST_SECOND_USER"


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When searching for files to be removed after being hidden we must use
find with `-path` instead of `-name` if we want to remove files in
subdirectories as well.

Does this close any currently open issues?
------------------------------------------
–

Any relevant logs, error output, etc?
-------------------------------------
–

Any other comments?
-------------------
–
