### PR TITLE
readme: change url to point to /installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [git-secret site](http://git-secret.io/).
 
 ## Installation
 
-See the [installation section](http://git-secret.io/#installation).
+See the [installation section](http://git-secret.io/installation).
 
 ## Contributing
 


### PR DESCRIPTION
Change the url to point to the file installation, not the anchor.

<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planing a large feature, please, discuss it first in the separate issue
1. Make sure that you open your pull-request to the `develop` branch (master branch is protected anyways)
2. Make sure that tests pass
3. Make sure that your code has the same style

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The link to Installation was pointing to an anchor that did not provide the desired installation instructions. The URL should point to /installation (page) not anchor.

Does this close any currently open issues?
------------------------------------------
No.

Any relevant logs, error output, etc?
-------------------------------------
No.

Any other comments?
-------------------
No.
