### PR TITLE
Add support to run on Git Bash for Windows (MINGW) system.

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -112,6 +112,10 @@ function _os_based {
     Linux)
       "$1_linux" "${@:2}"
     ;;
+	
+    MINGW*)
+      "$1_linux" "${@:2}"
+    ;;
 
     # TODO: add MS Windows support.
     # CYGWIN*|MINGW32*|MSYS*)


### PR DESCRIPTION
Requirement: Git Bash on Windows

Version tested:
GPG version: gpg (GnuPG) 1.4.21
git version 2.13.0.windows.1
GNU bash, version 4.4.12(1)-release (x86_64-pc-msys)
"uname.exe -s": MINGW64_NT-10.0

Output for bats test on Git Bash for Windows:

 ✓ run 'add' normally
 ✓ run 'add' for unignored file
 ✓ run 'add' for unignored file with '-i'
 ✓ run 'add' for unignored file with '-i' in subfolder
 ✓ run 'add' for relative path
 ✓ run 'add' for file in subfolder
 ✓ run 'add' twice for one file
 ✓ run 'add' for multiple files
 ✓ run 'changes' with one file changed
 ✓ run 'changes' with one file changed (with deletions)
 ✓ run 'changes' without changes
 ✓ run 'changes' with multiple files changed
 ✓ run 'changes' with multiple selected files changed
 ✓ run 'clean' normally
 ✓ run 'clean' with '-v'
 ✓ run 'hide' normally
 ✓ run 'hide' with multiple files
 ✓ run 'hide' with '-m'
 ✓ run 'hide' with '-m' twice
 ✓ run 'hide' with '-c' and '-v'
 ✓ run 'hide' with '-d'
 ✓ run 'hide' with '-d' and '-v'
 ✓ run 'hide' with '-d' and '-v' and files in subdirectories
 ✓ run 'hide' with multiple users
 ✓ run 'init' without '.git'
 ✓ run 'init' normally
 ✓ run 'init' in subfolder
 ✓ run 'init' with '.gitsecret' already inited
 ✓ run 'killperson' without arguments
 ✓ run 'killperson' with key name
 ✓ run 'killperson' with email
 ✓ run 'killperson' with multiple arguments
 ✓ run 'list' normally
 ✓ run 'list' with multiple files
 ✓ run 'list' on empty repo
 ✓ run 'git secret' without command
 ✓ run 'git secret' with bad command
 ✓ run 'git secret --version'
 ✓ run 'git secret --dry-run'
 ✓ run 'remove' normally
 ✓ run 'remove' with multiple arguments
 ✓ run 'remove' with slashes in filename
 ✓ run 'remove' with '-c'
 ✓ run 'reveal' with password argument
 ✓ run 'reveal' with '-f'
 ✓ run 'reveal' with wrong password
 ✓ run 'reveal' for attacker
 ✓ run 'reveal' for multiple users (with key deletion)
 ✓ run 'reveal' for multiple users (normally)
 ✓ run 'reveal' with different file extension
 ✓ fail on no users
 ✓ constantly fail on no users
 ✓ run 'tell' with secret-key imported
 ✓ run 'tell' without '.gitsecret'
 ✓ run 'tell' without arguments
 ✓ run 'tell' normally
 ✓ run 'tell' with '-m'
 ✓ run 'tell' with '-m' (empty email)
 ✓ run 'tell' with multiple emails
 ✓ run 'tell' in subfolder
 ✓ run 'usage'
 ✓ run 'usage' without '.git/'
 ✓ run 'usage' with ignored '.gitsecret/'
 ✓ run 'whoknows' normally
 ✓ run 'whoknows' in subfolder
 ✓ run 'whoknows' without any users
