### PR TITLE
improve error message when trying to 'git secret add' a file tracked by git

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -351,6 +351,18 @@ function _is_inside_git_tree {
   echo "$result"
 }
 
+function _is_tracked_in_git {
+  local filename="$1" # required
+  local result
+  result="$(git ls-files --error-unmatch "$filename" >/dev/null 2>&1; echo $?)"
+
+  if [[ "$result" -eq 0 ]]; then
+    echo "1"
+  else
+    echo "0"
+  fi
+}
+
 
 function _get_git_root_path {
   # We need this function to get the location of the `.git` folder,

--- a/src/commands/git_secret_add.sh
+++ b/src/commands/git_secret_add.sh
@@ -32,9 +32,14 @@ function add {
     normalized_path=$(_git_normalize_filename "$item")
     path=$(_append_root_path "$normalized_path")
 
+    # check that the file is not tracked
+    if [[ $(git ls-files --error-unmatch "$@") ]]; then
+        _abort "file tracked in git, consider using 'git rm --cached $@'"
+    fi
+
     # Checking that file is valid:
     if [[ ! -f "$path" ]]; then
-      _abort "$item is not a file."
+      _abort "not a file: $item"
     fi
 
     # Checking that it is ignored:

--- a/src/commands/git_secret_add.sh
+++ b/src/commands/git_secret_add.sh
@@ -33,8 +33,8 @@ function add {
     path=$(_append_root_path "$normalized_path")
 
     # check that the file is not tracked
-    if [[ $(git ls-files --error-unmatch "$@") ]]; then
-        _abort "file tracked in git, consider using 'git rm --cached $@'"
+    if [[ $(git ls-files --error-unmatch "$item") ]]; then
+        _abort "file tracked in git, consider using 'git rm --cached $item'"
     fi
 
     # Checking that file is valid:
@@ -52,7 +52,7 @@ function add {
     fi
   done
 
-  # Are there any uningnored files?
+  # Are there any unignored files?
 
   if [[ ! "${#not_ignored[@]}" -eq 0 ]]; then
     # And show them all at once.

--- a/src/commands/git_secret_add.sh
+++ b/src/commands/git_secret_add.sh
@@ -33,8 +33,10 @@ function add {
     path=$(_append_root_path "$normalized_path")
 
     # check that the file is not tracked
-    if [[ $(git ls-files --error-unmatch "$item") ]]; then
-        _abort "file tracked in git, consider using 'git rm --cached $item'"
+    local in_git
+    in_git=$(_is_tracked_in_git "$item")
+    if [[ "$in_git" -ne 0  ]]; then
+       _abort "file tracked in git, consider using 'git rm --cached $item'"
     fi
 
     # Checking that file is valid:
@@ -57,7 +59,7 @@ function add {
   if [[ ! "${#not_ignored[@]}" -eq 0 ]]; then
     # And show them all at once.
     local message
-    message="these files are not in .gitignore: $* ;"
+    message="these files are not in .gitignore: $*"
 
     if [[ "$auto_ignore" -eq 0 ]]; then
       # This file is not ignored. user don't want it to be added automatically.


### PR DESCRIPTION
Closes #126 

Now complains "file tracked in git, consider using 'git rm --cached yourfilename.txt'"