### PR TITLE
fixes for git secret changes

### DIFF
--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -37,13 +37,22 @@ function changes {
 
     local path # absolute path
     local normalized_path # relative to the .git dir
+    local encrypted_filename
     normalized_path=$(_git_normalize_filename "$filename")
+    encrypted_filename=$(_get_encrypted_filename "$filename")
 
+    if [[ ! -f "$encrypted_filename" ]]; then
+        _abort "cannot find encrypted version of file: $filename"
+    fi
     if [[ ! -z "$normalized_path" ]]; then
       path=$(_append_root_path "$normalized_path")
     else
       # Path was already normalized
       path=$(_append_root_path "$filename")
+    fi
+    
+    if [[ ! -f "$path" ]]; then
+        _abort "file not found. Consider using 'git secret reveal': $filename"
     fi
 
     # Now we have all the data required:

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -44,6 +44,20 @@ function teardown {
   [[ "$output" == *"+$new_content"* ]]
 }
 
+@test "run 'changes' with one source file missing" {
+  local password=$(test_user_password "$TEST_DEFAULT_USER")
+  #local new_content="new content"
+  #echo "$new_content" >> "$FILE_TO_HIDE"
+
+  run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
+  [ "$status" -ne 0 ]
+
+  ## Testing that output has both filename and changes:
+  #local fullpath=$(_append_root_path "$FILE_TO_HIDE")
+  #[[ "$output" == *"changes in $fullpath"* ]]
+  #[[ "$output" == *"+$new_content"* ]]
+}
+
 
 @test "run 'changes' with one file changed (with deletions)" {
   local password=$(test_user_password "$TEST_DEFAULT_USER")

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -44,18 +44,21 @@ function teardown {
   [[ "$output" == *"+$new_content"* ]]
 }
 
-@test "run 'changes' with one source file missing" {
+@test "run 'changes' with source file missing" {
   local password=$(test_user_password "$TEST_DEFAULT_USER")
-  #local new_content="new content"
-  #echo "$new_content" >> "$FILE_TO_HIDE"
+  rm "$FILE_TO_HIDE"
 
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
   [ "$status" -ne 0 ]
+}
 
-  ## Testing that output has both filename and changes:
-  #local fullpath=$(_append_root_path "$FILE_TO_HIDE")
-  #[[ "$output" == *"changes in $fullpath"* ]]
-  #[[ "$output" == *"+$new_content"* ]]
+@test "run 'changes' with hidden file missing" {
+  local password=$(test_user_password "$TEST_DEFAULT_USER")
+  local encrypted_file=$(_get_encrypted_filename $FILE_TO_HIDE)
+  rm "$encrypted_file"
+
+  run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
+  [ "$status" -ne 0 ]
 }
 
 


### PR DESCRIPTION
Closes #153 

Specifically:

 * checks that we can find unencrypted versions of hidden files, and     
 * checks we can find the unencrypted versions of hidden files

````
% git secret changes
 [shows expected output]

% git secret changes config.ini
 [shows changes just for config.ini]

% git secret changes no_such_file
git-secret: abort: cannot find encrypted version of file: no_such_file

% rm -f config.ini
  # note: config.ini.secret still exists

% git secret changes
git-secret: abort: file not found. Consider using 'git secret reveal': config.ini
````