### PR TITLE
remove link to non-existent tutorials page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,7 +27,6 @@
 
   <nav class="site-navigation">
     <a href="/installation">Installation</a>
-    <a href="/tutorials">Tutorials</a>
     <a href="{{ site.github_plugins }}">External plugins</a>
     <a href="{{ site.github_using }}">Projects using it</a>
     <a href="{{ site.github_changelog }}">Changelog</a>


### PR DESCRIPTION
Closes issue #132 .

Home page of already has our 'best' instructional usage data.
http://git-secret.io/
