### PR TITLE
Detect gpg error 136

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -538,7 +538,7 @@ function _user_required {
   local trustdb
   trustdb=$(_get_secrets_dir_keys_trustdb)
 
-  local error_message="no permitted users found. run 'git secret tell email@address'."
+  local error_message="no public keys for users found. run 'git secret tell email@address'."
   if [[ ! -f "$trustdb" ]]; then
     _abort "$error_message"
   fi
@@ -550,7 +550,10 @@ function _user_required {
   keys_exist=$($gpg_local -n --list-keys)
   local exit_code=$?
   if [[ exit_code -ne 0 ]]; then
-    _abort "unable to list public keys in gpg: exit code $exit_code"
+    # this might catch corner case where gpg --list-keys shows 
+    # 'gpg: skipped packet of type 12 in keybox' warnings but succeeds? 
+    # See #136
+    _abort "problem listing public keys in gpg: exit code $exit_code"
   fi
   if [[ -z "$keys_exist" ]]; then
     _abort "$error_message"

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -538,7 +538,7 @@ function _user_required {
   local trustdb
   trustdb=$(_get_secrets_dir_keys_trustdb)
 
-  local error_message="no users found. run 'git secret tell'."
+  local error_message="no permitted users found. run 'git secret tell email@address'."
   if [[ ! -f "$trustdb" ]]; then
     _abort "$error_message"
   fi
@@ -548,6 +548,10 @@ function _user_required {
 
   local keys_exist
   keys_exist=$($gpg_local -n --list-keys)
+  local exit_code=$?
+  if [[ exit_code -ne 0 ]]; then
+    _abort "unable to list public keys in gpg: exit code $exit_code"
+  fi
   if [[ -z "$keys_exist" ]]; then
     _abort "$error_message"
   fi

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -549,7 +549,7 @@ function _user_required {
   local keys_exist
   keys_exist=$($gpg_local -n --list-keys)
   local exit_code=$?
-  if [[ exit_code -ne 0 ]]; then
+  if [[ "$exit_code" -ne 0 ]]; then
     # this might catch corner case where gpg --list-keys shows 
     # 'gpg: skipped packet of type 12 in keybox' warnings but succeeds? 
     # See #136

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -43,7 +43,7 @@ function reveal {
     _decrypt "$path" "1" "$force" "$homedir" "$passphrase"
 
     if [[ ! -f "$path" ]]; then
-        _abort "cannot find decrypted version of file: $filename"
+      _abort "cannot find decrypted version of file: $filename"
     fi
 
     counter=$((counter+1))

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -42,6 +42,10 @@ function reveal {
     # The parameters are: filename, write-to-file, force, homedir, passphrase
     _decrypt "$path" "1" "$force" "$homedir" "$passphrase"
 
+    if [[ ! -f "$path" ]]; then
+        _abort "cannot find decrypted version of file: $filename"
+    fi
+
     counter=$((counter+1))
   done < "$path_mappings"
 


### PR DESCRIPTION
For #136 and #169 
Better error checking around gpg --list-keys, 
make sure we decrypt files as expected.