### PR TITLE
Revert "migrate from bats to bats-core "

### DIFF
--- a/.ci/integration/tasks/dependencies.yml
+++ b/.ci/integration/tasks/dependencies.yml
@@ -14,7 +14,7 @@
 
 - name: Get bats
   git:
-    repo: 'https://github.com/bats-core/bats-core.git'
+    repo: 'https://github.com/sstephenson/bats.git'
     dest: /opt/bats
 
 - name: Install bats

--- a/.ci/integration/tasks/prep-tests.yml
+++ b/.ci/integration/tasks/prep-tests.yml
@@ -24,7 +24,7 @@
 
 - name: Print gpg version
   debug:
-    msg: "Running test against {{ gpg_version.stdout_lines | first | string }}."
+    msg: "Running test againts {{ gpg_version.stdout_lines | first | string }}."
   changed_when: False
 
 - name: Copy git-secret src

--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,14 @@ uninstall:
 
 .PHONY: install-test
 install-test:
-	@if [ ! -d "vendor/bats-core" ]; then \
-	git clone https://github.com/bats-core/bats-core.git vendor/bats-core; fi
+	@if [ ! -d "vendor/bats" ]; then \
+	git clone https://github.com/sstephenson/bats.git vendor/bats; fi
 
 .PHONY: test
 test: install-test clean build
 	@chmod +x "./utils/tests.sh"; sync; \
 	export SECRET_PROJECT_ROOT="${PWD}"; \
-	export PATH="${PWD}/vendor/bats-core/bin:${PWD}:${PATH}"; \
+	export PATH="${PWD}/vendor/bats/bin:${PWD}:${PATH}"; \
 	"./utils/tests.sh"
 
 #
@@ -105,7 +105,7 @@ build-apk: clean build install-fpm
 test-apk-ci: install-test build-apk
 	@chmod +x "./utils/apk/apk-ci.sh"; sync; \
 	export SECRET_PROJECT_ROOT="${PWD}"; \
-	export PATH="${PWD}/vendor/bats-core/bin:${PATH}"; \
+	export PATH="${PWD}/vendor/bats/bin:${PATH}"; \
 	"./utils/apk/apk-ci.sh"
 
 .PHONY: deploy-apk
@@ -127,7 +127,7 @@ build-deb: clean build install-fpm
 test-deb-ci: install-test build-deb
 	@chmod +x "./utils/deb/deb-ci.sh"; sync; \
 	export SECRET_PROJECT_ROOT="${PWD}"; \
-	export PATH="${PWD}/vendor/bats-core/bin:${PATH}"; \
+	export PATH="${PWD}/vendor/bats/bin:${PATH}"; \
 	"./utils/deb/deb-ci.sh"
 
 .PHONY: deploy-deb
@@ -149,7 +149,7 @@ build-rpm: clean build install-fpm
 test-rpm-ci: install-test build-rpm
 	@chmod +x "./utils/rpm/rpm-ci.sh"; sync; \
 	export SECRET_PROJECT_ROOT="${PWD}"; \
-	export PATH="${PWD}/vendor/bats-core/bin:${PATH}"; \
+	export PATH="${PWD}/vendor/bats/bin:${PATH}"; \
 	"./utils/rpm/rpm-ci.sh"
 
 .PHONY: deploy-rpm
@@ -164,5 +164,5 @@ deploy-rpm: build-rpm
 test-make-ci: clean install-test
 	@chmod +x "./utils/make/make-ci.sh"; sync; \
 	export SECRET_PROJECT_ROOT="${PWD}"; \
-	export PATH="${PWD}/vendor/bats-core/bin:${PATH}"; \
+	export PATH="${PWD}/vendor/bats/bin:${PATH}"; \
 	"./utils/make/make-ci.sh"

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # This file is following a name convention defined in:
-#      https://github.com/sstephenson/bats 
-#  and https://github.com/bats-core/bats-core
+# https://github.com/sstephenson/bats
 
 # shellcheck disable=1090
 source "$SECRET_PROJECT_ROOT/src/version.sh"

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -4,15 +4,17 @@ set -e
 
 
 # Credit goes to:
-# https://github.com/bats-core/bats-core/blob/master/install.sh (with alterations)
+# https://github.com/sstephenson/bats/blob/master/install.sh
 function resolve_link {
-  $(type -p greadlink readlink | head -n1) "$1"
+  $(type -p greadlink readlink | head -1) "$1"
 }
 
 function abs_dirname {
   local cwd
-  cwd="$(pwd)"
   local path="$1"
+
+  cwd="$(pwd)"
+
 
   while [ -n "$path" ]; do
     cd "${path%/*}"
@@ -26,32 +28,20 @@ function abs_dirname {
 
 PREFIX="$1"
 if [ -z "$PREFIX" ]; then
-  { echo "usage: $0 <prefix>"
-    echo "  e.g. $0 /usr/local"
-  } >&2
+  echo "usage: $0 <prefix>" >&2
   exit 1
 fi
 
-BATS_ROOT="$(abs_dirname "$0")"
-mkdir -p "$PREFIX"/{bin,libexec,share/man/man{1,7}}
-cp -R "$BATS_ROOT"/bin/* "$PREFIX"/bin
-cp -R "$BATS_ROOT"/libexec/* "$PREFIX"/libexec
+SCRIPT_ROOT="$(dirname "$(abs_dirname "$0")")"
+
+mkdir -p "$PREFIX"/bin "$PREFIX"/share/man/man1 "$PREFIX"/share/man/man7
+cp "$SCRIPT_ROOT"/git-secret "$PREFIX"/bin/git-secret
+
 # There was an issue with this line:
 # cp -R "$SCRIPT_ROOT"/man/man1/* "$PREFIX"/share/man/man1
 # see https://github.com/sobolevn/git-secret/issues/35 for reference.
 find "$SCRIPT_ROOT"/man/man1 -name '*.1' -print0 | xargs -0 -I {} cp \
   -a {} "$PREFIX"/share/man/man1
 cp "$SCRIPT_ROOT"/man/man7/git-secret.7 "$PREFIX"/share/man/man7/git-secret.7
-
-# fix broken symbolic link file
-if [ ! -L "$PREFIX"/bin/bats ]; then
-    dir="$(readlink -e "$PREFIX")"
-    rm -f "$dir"/bin/bats
-    ln -s "$dir"/libexec/bats "$dir"/bin/bats
-fi
-
-# fix file permission
-chmod a+x "$PREFIX"/bin/*
-chmod a+x "$PREFIX"/libexec/*
 
 echo "Installed git-secret to ${PREFIX}/bin/git-secret"


### PR DESCRIPTION
Reverts sobolevn/git-secret#193
I think this causes #201, 'manual installation fails'
(The problem is in  utils/install.sh)

I'll recreate the port from bats to bats-core without this issue at a later time.