### PR TITLE
optimize git checkout of v1.0.2 tag of bats-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,7 @@ uninstall:
 .PHONY: install-test
 install-test:
 	@if [ ! -d "vendor/bats-core" ]; then \
-	git clone https://github.com/bats-core/bats-core.git vendor/bats-core; \
-	cd vendor/bats-core && git checkout v1.0.2; \
+	git clone --depth 1 -b v1.0.2 https://github.com/bats-core/bats-core.git vendor/bats-core; \
 	fi
 
 .PHONY: test


### PR DESCRIPTION
As per @simbo1905 's comment on PR #216:
>can we do --depth=1 so that it takes a very shallow copy of the code rather 
>than a full deep history which will slow things down over time?