### PR TITLE
Clarify that 'git-secret-add' doesn't alter .gitignore by default

### DIFF
--- a/src/commands/git_secret_usage.sh
+++ b/src/commands/git_secret_usage.sh
@@ -24,7 +24,7 @@ function usage {
   echo "usage: git secret [--version] [$commands]"
   echo " 'git secret --version' will show version and exit"
   echo "See 'git secret [command] -h' for more info about commands and their options"
-  echo " add [filename.txt] - adds file to be hidden. optionally adds file to .gitignore"
+  echo " add [filename.txt] - adds file to be hidden, optionally adds file to .gitignore"
   echo " cat [filename.txt] - cats the decrypted contents of the named file to stdout"
   echo " changes [filename.secret] - indicates if the file has changed since checkin"
   echo " clean - deletes encrypted files"

--- a/src/commands/git_secret_usage.sh
+++ b/src/commands/git_secret_usage.sh
@@ -24,7 +24,7 @@ function usage {
   echo "usage: git secret [--version] [$commands]"
   echo " 'git secret --version' will show version and exit"
   echo "See 'git secret [command] -h' for more information on each command below"
-  echo " add [filename.txt] - adds file to be hidden. Also add this file to .gitignore"
+  echo " add [filename.txt] - adds file to be hidden. Can also add file to .gitignore"
   echo " cat [filename.txt] - cats the decrypted contents of the named file to stdout"
   echo " changes [filename.secret] - indicates if the file has changed since checkin"
   echo " clean - deletes encrypted files"

--- a/src/commands/git_secret_usage.sh
+++ b/src/commands/git_secret_usage.sh
@@ -23,8 +23,8 @@ function usage {
 
   echo "usage: git secret [--version] [$commands]"
   echo " 'git secret --version' will show version and exit"
-  echo "See 'git secret [command] -h' for more information on each command below"
-  echo " add [filename.txt] - adds file to be hidden. Can also add file to .gitignore"
+  echo "See 'git secret [command] -h' for more info about commands and their options"
+  echo " add [filename.txt] - adds file to be hidden. optionally adds file to .gitignore"
   echo " cat [filename.txt] - cats the decrypted contents of the named file to stdout"
   echo " changes [filename.secret] - indicates if the file has changed since checkin"
   echo " clean - deletes encrypted files"


### PR DESCRIPTION
Changes git-secret usage output to indicate that 'git secret add' doesn't alter .gitignore by default.

For Issue #220, "Add File does not add to GitIgnore (per docs)"