### PR TITLE
allow spaces in path

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -420,19 +420,6 @@ function _get_secrets_dir_paths_mapping {
 
 # Logic:
 
-function _get_gpg_local {
-  # This function is required to return proper `gpg` command.
-  # This function was created due to this bug:
-  # https://github.com/sobolevn/git-secret/issues/85
-
-  local homedir
-  homedir=$(_get_secrets_dir_keys)
-
-  local gpg_local="$SECRETS_GPG_COMMAND --homedir=$homedir --no-permission-warning"
-  echo "$gpg_local"
-}
-
-
 function _abort {
   local message="$1" # required
 
@@ -543,11 +530,11 @@ function _user_required {
     _abort "$error_message"
   fi
 
-  local gpg_local
-  gpg_local=$(_get_gpg_local)
+  local secrets_dir_keys
+  secrets_dir_keys=$(_get_secrets_dir_keys)
 
   local keys_exist
-  keys_exist=$($gpg_local -n --list-keys)
+  keys_exist=$($SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning -n --list-keys)
   local exit_code=$?
   if [[ "$exit_code" -ne 0 ]]; then
     # this might catch corner case where gpg --list-keys shows 
@@ -579,10 +566,9 @@ function _parse_keyring_users {
 
   local result
 
-  local gpg_local
-  gpg_local=$(_get_gpg_local)
-
-  result=$($gpg_local --list-public-keys --with-colon | sed -n "$sed_pattern")
+  local secrets_dir_keys
+  secrets_dir_keys=$(_get_secrets_dir_keys)
+  result=$($SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --list-public-keys --with-colon | sed -n "$sed_pattern")
   echo "$result"
 }
 
@@ -618,31 +604,31 @@ function _decrypt {
   local encrypted_filename
   encrypted_filename=$(_get_encrypted_filename "$filename")
 
-  local base="$SECRETS_GPG_COMMAND --use-agent --decrypt --no-permission-warning"
+  local args=( "--use-agent" "--decrypt" "--no-permission-warning" )
 
   if [[ "$write_to_file" -eq 1 ]]; then
-    base="$base -o $filename"
+    args+=( "-o" "$filename" )
   fi
 
   if [[ "$force" -eq 1 ]]; then
-    base="$base --yes"
+    args+=( "--yes" )
   fi
 
   if [[ ! -z "$homedir" ]]; then
-    base="$base --homedir=$homedir"
+    args+=( "--homedir" "$homedir" )
   fi
 
   if [[ "$GPG_VER_21" -eq 1 ]]; then
-    base="$base --pinentry-mode loopback"
+    args+=( "--pinentry-mode" "loopback" )
   fi
 
   local exit_code
   if [[ ! -z "$passphrase" ]]; then
-    echo "$passphrase" | $base --quiet --batch --yes --no-tty --passphrase-fd 0 \
+    echo "$passphrase" | $SECRETS_GPG_COMMAND "${args[@]}" --quiet --batch --yes --no-tty --passphrase-fd 0 \
       "$encrypted_filename"
     exit_code=$?
   else
-    $base --quiet "$encrypted_filename"
+    $SECRETS_GPG_COMMAND "${args[@]}" "--quiet" "$encrypted_filename"
     exit_code=$?
   fi
   if [[ "$exit_code" -ne 0 ]]; then

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -146,6 +146,9 @@ function hide {
     local recipients
     recipients=$(_get_recipients)
 
+    local secrets_dir_keys
+    secrets_dir_keys=$(_get_secrets_dir_keys)
+
     local input_path
     local output_path
     input_path=$(_append_root_path "$filename")
@@ -156,10 +159,8 @@ function hide {
     # encrypt file only if required
     if [[ "$fsdb_file_hash" != "$file_hash" ]]; then
       # shellcheck disable=2086
-      local secrets_dir_keys
-      secrets_dir_keys=$(_get_secrets_dir_keys)
       $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" "--no-permission-warning" --use-agent --yes --trust-model=always --encrypt \
-        $recipients -o "$output_path" "$input_path" > /dev/null 2>&1
+        "$recipients" -o "$output_path" "$input_path" > /dev/null 2>&1
       local exit_code=$?
       if [[ "$exit_code" -ne 0 ]]; then
         _abort "problem encrypting file with gpg: exit code $exit_code: $filename"

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -158,9 +158,10 @@ function hide {
 
     # encrypt file only if required
     if [[ "$fsdb_file_hash" != "$file_hash" ]]; then
-      # shellcheck disable=2086
+      # we depend on $recipients being split on whitespace
+      # shellcheck disable=SC2086
       $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" "--no-permission-warning" --use-agent --yes --trust-model=always --encrypt \
-        "$recipients" -o "$output_path" "$input_path" > /dev/null 2>&1
+        $recipients -o "$output_path" "$input_path" > /dev/null 2>&1
       local exit_code=$?
       if [[ "$exit_code" -ne 0 ]]; then
         _abort "problem encrypting file with gpg: exit code $exit_code: $filename"

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -146,9 +146,6 @@ function hide {
     local recipients
     recipients=$(_get_recipients)
 
-    local gpg_local
-    gpg_local=$(_get_gpg_local)
-
     local input_path
     local output_path
     input_path=$(_append_root_path "$filename")
@@ -159,7 +156,9 @@ function hide {
     # encrypt file only if required
     if [[ "$fsdb_file_hash" != "$file_hash" ]]; then
       # shellcheck disable=2086
-      $gpg_local --use-agent --yes --trust-model=always --encrypt \
+      local secrets_dir_keys
+      secrets_dir_keys=$(_get_secrets_dir_keys)
+      $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" "--no-permission-warning" --use-agent --yes --trust-model=always --encrypt \
         $recipients -o "$output_path" "$input_path" > /dev/null 2>&1
       local exit_code=$?
       if [[ "$exit_code" -ne 0 ]]; then

--- a/src/commands/git_secret_killperson.sh
+++ b/src/commands/git_secret_killperson.sh
@@ -25,9 +25,10 @@ function killperson {
     _abort "at least one email is required for killperson."
   fi
 
+  # Getting the local git-secret `gpg` key directory:
+  local secrets_dir_keys
+  secrets_dir_keys=$(_get_secrets_dir_keys)
   for email in "${emails[@]}"; do
-    local secrets_dir_keys
-    secrets_dir_keys=$(_get_secrets_dir_keys)
     $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --batch --yes --delete-key "$email"
     local exit_code=$?
     if [[ "$exit_code" -ne 0 ]]; then

--- a/src/commands/git_secret_killperson.sh
+++ b/src/commands/git_secret_killperson.sh
@@ -25,12 +25,10 @@ function killperson {
     _abort "at least one email is required for killperson."
   fi
 
-  # Getting the local `gpg` command:
-  local gpg_local
-  gpg_local=$(_get_gpg_local)
-
   for email in "${emails[@]}"; do
-    $gpg_local --batch --yes --delete-key "$email"
+    local secrets_dir_keys
+    secrets_dir_keys=$(_get_secrets_dir_keys)
+    $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --batch --yes --delete-key "$email"
     local exit_code=$?
     if [[ "$exit_code" -ne 0 ]]; then
       _abort "problem deleting key for '$email' with gpg: exit code $exit_code"

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -8,9 +8,9 @@ END { print cnt }
 '
 
 function get_gpg_key_count {
-  local gpg_local
-  gpg_local=$(_get_gpg_local)
-  $gpg_local --list-public-keys --with-colon | gawk "$AWK_GPG_KEY_CNT"
+  local secrets_dir_keys
+  secrets_dir_keys=$(_get_secrets_dir_keys)
+  $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --list-public-keys --with-colon | gawk "$AWK_GPG_KEY_CNT"
   local exit_code=$?
   if [[ "$exit_code" -ne 0 ]]; then
     _abort "problem counting keys with gpg: exit code $exit_code"
@@ -91,9 +91,9 @@ function tell {
     fi
 
     # Importing public key to the local keychain:
-    local gpg_local
-    gpg_local=$(_get_gpg_local)
-    $gpg_local --import "$keyfile" > /dev/null 2>&1
+    local secrets_dir_keys
+    secrets_dir_keys=$(_get_secrets_dir_keys)
+    $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --import "$keyfile" > /dev/null 2>&1
     exit_code=$?
     if [[ "$exit_code" -ne 0 ]]; then
       _abort "problem importing public key for '$email' with gpg: exit code $exit_code"

--- a/utils/tests.sh
+++ b/utils/tests.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+## Running all the bats-tests:
+#cd "${SECRET_PROJECT_ROOT}"; rm -rf temp; mkdir temp; cd temp;
+#bats "${SECRET_PROJECT_ROOT}/tests"
+
 # Running all the bats-tests:
-cd "${SECRET_PROJECT_ROOT}"; rm -rf temp; mkdir temp; cd temp;
+cd "${SECRET_PROJECT_ROOT}"; rm -rf 'tempdir with spaces'; mkdir 'tempdir with spaces'; cd 'tempdir with spaces';
 bats "${SECRET_PROJECT_ROOT}/tests"

--- a/utils/tests.sh
+++ b/utils/tests.sh
@@ -4,10 +4,6 @@
 
 set -e
 
-# Running all the bats-tests:
-cd "${SECRET_PROJECT_ROOT}"; rm -rf temp; mkdir temp; cd temp;
+# Running all the bats-tests in a dir with spaces:
+cd "${SECRET_PROJECT_ROOT}"; rm -rf 'tempdir with spaces'; mkdir 'tempdir with spaces'; cd 'tempdir with spaces';
 bats "${SECRET_PROJECT_ROOT}/tests"
-
-## Running all the bats-tests in a dir with spaces:
-##cd "${SECRET_PROJECT_ROOT}"; rm -rf 'tempdir with spaces'; mkdir 'tempdir with spaces'; cd 'tempdir with spaces';
-#bats "${SECRET_PROJECT_ROOT}/tests"

--- a/utils/tests.sh
+++ b/utils/tests.sh
@@ -4,10 +4,10 @@
 
 set -e
 
-## Running all the bats-tests:
-#cd "${SECRET_PROJECT_ROOT}"; rm -rf temp; mkdir temp; cd temp;
-#bats "${SECRET_PROJECT_ROOT}/tests"
-
 # Running all the bats-tests:
-cd "${SECRET_PROJECT_ROOT}"; rm -rf 'tempdir with spaces'; mkdir 'tempdir with spaces'; cd 'tempdir with spaces';
+cd "${SECRET_PROJECT_ROOT}"; rm -rf temp; mkdir temp; cd temp;
 bats "${SECRET_PROJECT_ROOT}/tests"
+
+## Running all the bats-tests in a dir with spaces:
+##cd "${SECRET_PROJECT_ROOT}"; rm -rf 'tempdir with spaces'; mkdir 'tempdir with spaces'; cd 'tempdir with spaces';
+#bats "${SECRET_PROJECT_ROOT}/tests"


### PR DESCRIPTION
Fixes issue #135, regarding spaces in pathnames.

Works around issue with `_get_gpg_local()` function when returning pathnames with spaces.

We could store the results of `_get_secrets_dir_keys()` in a global variable if that's preferable. Reviewers, let me know.