### PR TITLE
Test that emails used on 'tell' exist verbatim in users's keychain

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -567,9 +567,15 @@ function _get_encrypted_filename {
 }
 
 
+function _get_users_in_gpg_keyring {
+  local result
+  result=$($SECRETS_GPG_COMMAND --no-permission-warning --list-public-keys --with-colon --fixed-list-mode | grep ^uid: | gawk -F':' '{print $10;}' | sed 's/.*<\(.*\)>.*/\1/')
+
+  echo "$result"
+}
 
 
-function _get_users_in_keyring {
+function _get_users_in_gitsecret_keyring {
   # This function is required to show the users in the keyring.
   # `whoknows` command uses it internally.
   # It basically just parses the `gpg` public keys
@@ -592,7 +598,7 @@ function _get_recipients {
   # It basically just parses the `gpg` public keys
 
   local result
-  result=$(_get_users_in_keyring | sed 's/^/-r/')   # put -r before each user
+  result=$(_get_users_in_gitsecret_keyring | sed 's/^/-r/')   # put -r before each user
   echo "$result"
 }
 

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -64,6 +64,20 @@ function tell {
     _abort "you must provide at least one email address."
   fi
 
+  local gpg_uids
+  gpg_uids=$(_get_users_in_gpg_keyring)
+  for email in "${emails[@]}"; do
+    local email_ok=0
+    for uid in $gpg_uids; do
+        if [[ "$uid" == "$email" ]]; then
+            email_ok=1
+        fi
+    done
+    if [[ "$email_ok" == 0 ]]; then
+      _abort "email not found in gpg keyring: $email"
+    fi
+  done
+
   local start_key_cnt
   start_key_cnt=$(get_gpg_key_count)
   for email in "${emails[@]}"; do

--- a/src/commands/git_secret_whoknows.sh
+++ b/src/commands/git_secret_whoknows.sh
@@ -21,6 +21,6 @@ function whoknows {
   local keys
 
   # Getting the users from gpg:
-  keys=$(_get_users_in_keyring)
+  keys=$(_get_users_in_gitsecret_keyring)
   echo "$keys"
 }


### PR DESCRIPTION
Closes #176  by checking that the email passed was found in the user's gpg keychain.