### PR TITLE
add -P (preserve permission) option to reveal and hide. For #172

### DIFF
--- a/man/man1/git-secret-add.1
+++ b/man/man1/git-secret-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-ADD" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-ADD" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-add\fR \- starts to track added files\.

--- a/man/man1/git-secret-cat.1
+++ b/man/man1/git-secret-cat.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CAT" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-CAT" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-cat\fR \- decrypts files passed on command line to stdout

--- a/man/man1/git-secret-changes.1
+++ b/man/man1/git-secret-changes.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CHANGES" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-CHANGES" "1" "July 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-changes\fR \- view diff of the hidden files\.
@@ -15,7 +15,7 @@ git secret changes [\-h] [\-d dir] [\-p password] [pathspec]\.\.\.
 .fi
 .
 .SH "DESCRIPTION"
-\fBgit\-secret\-changes\fR \- shows changes between the current version of hidden files and the ones already commited\. You can provide any number of hidden files to this command as arguments, and it will show changes for these files only\. Note that files must be specified by their encrypted names, typically \fBfilename\.yml\.secret\fR\. If no arguments are provided, information about all hidden files will be shown\.
+\fBgit\-secret\-changes\fR \- shows changes between the current version of hidden files and the ones already committed\. You can provide any number of hidden files to this command as arguments, and it will show changes for these files only\. Note that files must be specified by their encrypted names, typically \fBfilename\.yml\.secret\fR\. If no arguments are provided, information about all hidden files will be shown\.
 .
 .SH "OPTIONS"
 .

--- a/man/man1/git-secret-clean.1
+++ b/man/man1/git-secret-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CLEAN" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-CLEAN" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-clean\fR \- removes all the hidden files\.

--- a/man/man1/git-secret-hide.1
+++ b/man/man1/git-secret-hide.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-HIDE" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-HIDE" "1" "August 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-hide\fR \- encrypts all added files with the inner keyring\.
@@ -10,7 +10,7 @@
 .
 .nf
 
-git secret hide [\-c] [\-v]
+git secret hide [\-c] [\-P] [\-v] [\-d] [\-m]
 .
 .fi
 .
@@ -26,6 +26,7 @@ It is possible to modify the names of the encrypted files by setting \fBSECRETS_
 
 \-v  \- verbose, shows extra information\.
 \-c  \- deletes encrypted files before creating new ones\.
+\-P  \- preserve permissions of unencrypted file in encrypted file\.
 \-d  \- deletes unencrypted files after encryption\.
 \-m  \- encrypt files only when modified\.
 \-h  \- shows help\.

--- a/man/man1/git-secret-hide.1.ronn
+++ b/man/man1/git-secret-hide.1.ronn
@@ -3,7 +3,7 @@ git-secret-hide - encrypts all added files with the inner keyring.
 
 ## SYNOPSIS
 
-    git secret hide [-c] [-C] [-v] [-d] [-m]
+    git secret hide [-c] [-P] [-v] [-d] [-m]
 
 
 ## DESCRIPTION
@@ -19,7 +19,7 @@ It is possible to modify the names of the encrypted files by setting `SECRETS_EX
 
     -v  - verbose, shows extra information.
     -c  - deletes encrypted files before creating new ones.
-    -C  - sets permissions of encrypted file to match unencrypted file
+    -P  - preserve permissions of unencrypted file in encrypted file.
     -d  - deletes unencrypted files after encryption.
     -m  - encrypt files only when modified.
     -h  - shows help.

--- a/man/man1/git-secret-hide.1.ronn
+++ b/man/man1/git-secret-hide.1.ronn
@@ -3,7 +3,7 @@ git-secret-hide - encrypts all added files with the inner keyring.
 
 ## SYNOPSIS
 
-    git secret hide [-c] [-v]
+    git secret hide [-c] [-C] [-v] [-d] [-m]
 
 
 ## DESCRIPTION
@@ -19,6 +19,7 @@ It is possible to modify the names of the encrypted files by setting `SECRETS_EX
 
     -v  - verbose, shows extra information.
     -c  - deletes encrypted files before creating new ones.
+    -C  - sets permissions of encrypted file to match unencrypted file
     -d  - deletes unencrypted files after encryption.
     -m  - encrypt files only when modified.
     -h  - shows help.

--- a/man/man1/git-secret-init.1
+++ b/man/man1/git-secret-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-INIT" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-INIT" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-init\fR \- initializes git\-secret repository\.

--- a/man/man1/git-secret-killperson.1
+++ b/man/man1/git-secret-killperson.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-KILLPERSON" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-KILLPERSON" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-killperson\fR \- deletes key identified by an email from the inner keyring\.

--- a/man/man1/git-secret-list.1
+++ b/man/man1/git-secret-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-LIST" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-LIST" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-list\fR \- prints all the added files\.

--- a/man/man1/git-secret-remove.1
+++ b/man/man1/git-secret-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REMOVE" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-REMOVE" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-remove\fR \- removes files from index\.

--- a/man/man1/git-secret-reveal.1
+++ b/man/man1/git-secret-reveal.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REVEAL" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-REVEAL" "1" "August 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-reveal\fR \- decrypts all added files\.
@@ -10,7 +10,7 @@
 .
 .nf
 
-git secret reveal [\-f] [\-d dir] [\-p password]
+git secret reveal [\-f] [\-P] [\-d dir] [\-p password]
 .
 .fi
 .
@@ -21,9 +21,10 @@ git secret reveal [\-f] [\-d dir] [\-p password]
 .
 .nf
 
-\-f  \- forces to overwrite exisiting files without prompt\.
+\-f  \- forces to overwrite existing files without prompt\.
 \-d  \- specifies `\-\-homedir` option for the `gpg`, basically use this option if you store your keys in a custom location\.
 \-p  \- specifies password for noinput mode, adds `\-\-passphrase` option for `gpg`\.
+\-P  \- preserve permissions of encrypted file in unencrypted file\.
 \-h  \- shows help\.
 .
 .fi

--- a/man/man1/git-secret-reveal.1.ronn
+++ b/man/man1/git-secret-reveal.1.ronn
@@ -3,7 +3,7 @@ git-secret-reveal - decrypts all added files.
 
 ## SYNOPSIS
 
-    git secret reveal [-f] [-c] [-d dir] [-p password]
+    git secret reveal [-f] [-C] [-d dir] [-p password]
 
 
 ## DESCRIPTION
@@ -18,7 +18,7 @@ Under the hood, this uses the `gpg --decrypt` command.
     -f  - forces to overwrite existing files without prompt.
     -d  - specifies `--homedir` option for the `gpg`, basically use this option if you store your keys in a custom location.
     -p  - specifies password for noinput mode, adds `--passphrase` option for `gpg`.
-    -c  - attempts to set decrypted file to same permissions as encrypted file (normally would be -p but that's used above).
+    -C  - set decrypted file to same permissions as encrypted file.
     -h  - shows help.
 
 

--- a/man/man1/git-secret-reveal.1.ronn
+++ b/man/man1/git-secret-reveal.1.ronn
@@ -3,7 +3,7 @@ git-secret-reveal - decrypts all added files.
 
 ## SYNOPSIS
 
-    git secret reveal [-f] [-d dir] [-p password]
+    git secret reveal [-f] [-c] [-d dir] [-p password]
 
 
 ## DESCRIPTION
@@ -18,6 +18,7 @@ Under the hood, this uses the `gpg --decrypt` command.
     -f  - forces to overwrite existing files without prompt.
     -d  - specifies `--homedir` option for the `gpg`, basically use this option if you store your keys in a custom location.
     -p  - specifies password for noinput mode, adds `--passphrase` option for `gpg`.
+    -c  - attempts to set decrypted file to same permissions as encrypted file (normally would be -p but that's used above).
     -h  - shows help.
 
 

--- a/man/man1/git-secret-reveal.1.ronn
+++ b/man/man1/git-secret-reveal.1.ronn
@@ -3,7 +3,7 @@ git-secret-reveal - decrypts all added files.
 
 ## SYNOPSIS
 
-    git secret reveal [-f] [-C] [-d dir] [-p password]
+    git secret reveal [-f] [-P] [-d dir] [-p password]
 
 
 ## DESCRIPTION
@@ -18,7 +18,7 @@ Under the hood, this uses the `gpg --decrypt` command.
     -f  - forces to overwrite existing files without prompt.
     -d  - specifies `--homedir` option for the `gpg`, basically use this option if you store your keys in a custom location.
     -p  - specifies password for noinput mode, adds `--passphrase` option for `gpg`.
-    -C  - set decrypted file to same permissions as encrypted file.
+    -P  - preserve permissions of encrypted file in unencrypted file.
     -h  - shows help.
 
 

--- a/man/man1/git-secret-tell.1
+++ b/man/man1/git-secret-tell.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-TELL" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-TELL" "1" "July 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-tell\fR \- adds a person, who can access private data\.
@@ -15,7 +15,7 @@ git secret tell [\-m] [\-d dir] [emails]\.\.\.
 .fi
 .
 .SH "DESCRIPTION"
-\fBgit\-secret\-tell\fR receives an email addresses as an input, searches for the \fBgpg\fR\-key in the \fBgpg\fR\'s \fBhomedir\fR by these emails, then imports a person\'s public key into the \fBgit\-secret\fR\'s inner keychain\. From this moment this person can encrypt new files with the keyring which contains their key\. But they cannot decrypt the old files, which were already encrypted without their key\. They should be reencrypted with the new keyring by someone, who has the unencrypted files\.
+\fBgit\-secret\-tell\fR receives an email addresses as an input, searches for the \fBgpg\fR\-key in the \fBgpg\fR\'s \fBhomedir\fR by these emails, then imports a person\'s public key into the \fBgit\-secret\fR\'s inner keychain\. From this moment this person can encrypt new files with the keyring which contains their key, but they cannot decrypt the old files, which were already encrypted without their key\. The files should be re\-encrypted with the new keyring by someone who has the unencrypted files\.
 .
 .P
 \fBDo not manually import secret key into \fBgit\-secret\fR\fR\. Anyways, it won\'t work with any of the secret\-keys imported\.

--- a/man/man1/git-secret-usage.1
+++ b/man/man1/git-secret-usage.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-USAGE" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-USAGE" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-usage\fR \- prints all the available commands\.

--- a/man/man1/git-secret-whoknows.1
+++ b/man/man1/git-secret-whoknows.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-WHOKNOWS" "1" "May 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-WHOKNOWS" "1" "June 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-whoknows\fR \- prints email\-labels for each key in the keyring\.

--- a/man/man7/git-secret.7
+++ b/man/man7/git-secret.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET" "7" "June 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET" "7" "July 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\fR
@@ -44,7 +44,7 @@ Get their \fBgpg\fR public\-key\. \fBYou won\'t need their secret key\.\fR
 Import this key into your \fBgpg\fR setup (in ~/\.gnupg or similar) by running \fBgpg \-\-import KEY_NAME\.txt\fR
 .
 .IP "3." 4
-Now add this person to your secrets repo by running \fBgit secret tell persons@email\.id\fR (this will be the email address assocated with the public key)
+Now add this person to your secrets repo by running \fBgit secret tell persons@email\.id\fR (this will be the email address associated with the public key)
 .
 .IP "4." 4
 The newly added user cannot yet read the encrypted files\. Now, re\-encrypt the files using \fBgit secret reveal; git secret hide \-d\fR, and then commit and push the newly encrypted files\. (The \-d options deletes the unencrypted file after re\-encrypting it)\. Now the newly added user be able to decrypt the files in the repo using \fBgit\-secret\fR\.
@@ -52,7 +52,7 @@ The newly added user cannot yet read the encrypted files\. Now, re\-encrypt the 
 .IP "" 0
 .
 .P
-Note that it is possible to add yourself to the git\-secret repo without decrypting existing files\. It will be possible to decrypt them after reencrypting them with the new keyring\. So, if you don\'t want unexpected keys added, you can configure some server\-side security policy with the \fBpre\-receive\fR hook\.
+Note that it is possible to add yourself to the git\-secret repo without decrypting existing files\. It will be possible to decrypt them after re\-encrypting them with the new keyring\. So, if you don\'t want unexpected keys added, you can configure some server\-side security policy with the \fBpre\-receive\fR hook\.
 .
 .SH "Configuration"
 You can configure the version of gpg used, or the extension your encrypted files use, to suit your workflow better\. To do so, just set the required variable to the value you need\. This can be done in your shell environment file or with each \fBgit\-secret\fR command\.
@@ -90,7 +90,7 @@ This directory currently contains only the file \fBmapping\.cfg\fR, which lists 
 All the other internal data is stored in the directory:
 .
 .SS "<code>\.gitsecret/keys</code>"
-This directory contains data used by git\-secret and PGP to allow and maintain the correct encyption and access rights for the permitted parties\.
+This directory contains data used by git\-secret and PGP to allow and maintain the correct encryption and access rights for the permitted parties\.
 .
 .P
 Generally speaking, all the files in this directory \fIexcept\fR \fBrandom_seed\fR should be checked into your repo\.

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -16,6 +16,7 @@ _SECRETS_DIR_PATHS_MAPPING="${_SECRETS_DIR_PATHS}/mapping.cfg"
 # Commands:
 : "${SECRETS_GPG_COMMAND:="gpg"}"
 : "${SECRETS_CHECKSUM_COMMAND:="_os_based __sha256"}"
+: "${SECRETS_OCTAL_PERMS_COMMAND:="_os_based __get_octal_perms"}"
 
 
 # AWK scripts:
@@ -203,6 +204,11 @@ function _unique_filename {
   done
   echo "$result"
 }
+
+#function _get_octal_perms {
+#   local file=$1
+#   perms=$(stat -f "'%a'" "$filename")
+#}
 
 # Helper function
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -205,11 +205,6 @@ function _unique_filename {
   echo "$result"
 }
 
-#function _get_octal_perms {
-#   local file=$1
-#   perms=$(stat -f "'%a'" "$filename")
-#}
-
 # Helper function
 
 

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -21,6 +21,6 @@ function __get_octal_perms_linux {
   local filename
   filename=$1
   local perms
-  perms=$(stat --format "'%a'" "$filename")
+  perms=$(stat --format '%a' "$filename")
   echo "$perms"
 }

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -16,3 +16,9 @@ function __temp_file_linux {
 function __sha256_linux {
   sha256sum "$1"
 }
+
+function __get_octal_perms_linux {
+   local file=$1
+   perms=$(stat --format "'%a'" "$filename")
+   echo "$perms"
+}

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -18,7 +18,9 @@ function __sha256_linux {
 }
 
 function __get_octal_perms_linux {
-   local file=$1
-   perms=$(stat --format "'%a'" "$filename")
-   echo "$perms"
+  local filename
+  filename=$1
+  local perms
+  perms=$(stat --format "'%a'" "$filename")
+  echo "$perms"
 }

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -22,6 +22,6 @@ function __get_octal_perms_osx {
   local filename
   filename=$1
   local perms
-  perms=$(stat -f "'%p'" "$filename")
+  perms=$(stat -f '%p' "$filename")
   echo "$perms"
 }

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -18,3 +18,9 @@ function __temp_file_osx {
 function __sha256_osx {
   /usr/bin/shasum -a256 "$1"
 }
+function __get_octal_perms_osx {
+  local file=$1
+  local perms
+  perms=$(stat -f "'%p'" "$filename")
+  echo "$perms"
+}

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -19,7 +19,8 @@ function __sha256_osx {
   /usr/bin/shasum -a256 "$1"
 }
 function __get_octal_perms_osx {
-  local file=$1
+  local filename
+  filename=$1
   local perms
   perms=$(stat -f "'%p'" "$filename")
   echo "$perms"

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -80,18 +80,18 @@ function _optional_fsdb_update_hash {
 
 function hide {
   local clean=0
-  local chmod=0
+  local preserve=0
   local delete=0
   local fsdb_update_hash=0 # add checksum hashes to fsdb
   local verbose=''
 
   OPTIND=1
 
-  while getopts 'cCdmvh' opt; do
+  while getopts 'cPdmvh' opt; do
     case "$opt" in
       c) clean=1;;
 
-      C) chmod=1;;
+      P) preserve=1;;
 
       d) delete=1;;
 
@@ -164,7 +164,7 @@ function hide {
         _abort "problem encrypting file with gpg: exit code $exit_code: $filename"
       fi
 
-      if [[ "$chmod" == 1 ]]; then
+      if [[ "$preserve" == 1 ]]; then
         local perms
         perms=$($SECRETS_OCTAL_PERMS_COMMAND "$input_path")
         chmod "$perms" "$output_path"

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -80,15 +80,18 @@ function _optional_fsdb_update_hash {
 
 function hide {
   local clean=0
+  local chmod=0
   local delete=0
   local fsdb_update_hash=0 # add checksum hashes to fsdb
   local verbose=''
 
   OPTIND=1
 
-  while getopts 'cdmvh' opt; do
+  while getopts 'cCdmvh' opt; do
     case "$opt" in
       c) clean=1;;
+
+      C) chmod=1;;
 
       d) delete=1;;
 
@@ -160,6 +163,14 @@ function hide {
       if [[ "$exit_code" -ne 0 ]]; then
         _abort "problem encrypting file with gpg: exit code $exit_code: $filename"
       fi
+
+      if [[ "$chmod" == 1 ]]; then
+        local perms
+        perms=$($SECRETS_OCTAL_PERMS_COMMAND "$input_path")
+        chmod "$perms" "$output_path"
+      fi
+
+
       # If -m option was provided, it will update unencrypted file hash
       local key="$filename"
       local hash="$file_hash"

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -5,14 +5,17 @@ function reveal {
   local homedir=''
   local passphrase=''
   local force=0
+  local chmod=0
 
   OPTIND=1
 
-  while getopts 'hfd:p:' opt; do
+  while getopts 'chfd:p:' opt; do
     case "$opt" in
       h) _show_manual_for 'reveal';;
 
       f) force=1;;
+
+      c) chmod=1;;
 
       p) passphrase=$OPTARG;;
 
@@ -44,6 +47,12 @@ function reveal {
 
     if [[ ! -f "$path" ]]; then
       _abort "cannot find decrypted version of file: $filename"
+    fi
+
+    if [[ "$chmod" ]]; then
+        local perms
+        perms=$(stat -f "%Op" "$filename")
+        chmod "$perms" "$path"
     fi
 
     counter=$((counter+1))

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -9,13 +9,13 @@ function reveal {
 
   OPTIND=1
 
-  while getopts 'chfd:p:' opt; do
+  while getopts 'hfCd:p:' opt; do
     case "$opt" in
       h) _show_manual_for 'reveal';;
 
       f) force=1;;
 
-      c) chmod=1;;
+      C) chmod=1;;
 
       p) passphrase=$OPTARG;;
 

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -5,17 +5,17 @@ function reveal {
   local homedir=''
   local passphrase=''
   local force=0
-  local chmod=0
+  local preserve=0
 
   OPTIND=1
 
-  while getopts 'hfCd:p:' opt; do
+  while getopts 'hfPd:p:' opt; do
     case "$opt" in
       h) _show_manual_for 'reveal';;
 
       f) force=1;;
 
-      C) chmod=1;;
+      P) preserve=1;;
 
       p) passphrase=$OPTARG;;
 
@@ -49,7 +49,7 @@ function reveal {
       _abort "cannot find decrypted version of file: $filename"
     fi
 
-    if [[ "$chmod" == 1 ]]; then
+    if [[ "$preserve" == 1 ]]; then
       local secret_file
       secret_file=$(_get_encrypted_filename "$path")
       local perms

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -49,10 +49,15 @@ function reveal {
       _abort "cannot find decrypted version of file: $filename"
     fi
 
-    if [[ "$chmod" ]]; then
+    if [[ "$chmod" == 1 ]]; then
         local perms
-        perms=$(stat -f "%Op" "$filename")
-        chmod "$perms" "$path"
+	perms=$($SECRETS_OCTAL_PERMS_COMMAND "$filename")
+
+	echo "# octal_perms_command: $SECRETS_OCTAL_PERMS_COMMAND" >&3
+	echo "# filename is '$filename', path is '$path'" >&3
+	echo "# NOT running: chmod $perms $path" >&3
+
+        #chmod "$perms" "$path"
     fi
 
     counter=$((counter+1))

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -50,10 +50,16 @@ function reveal {
     fi
 
     if [[ "$chmod" == 1 ]]; then
+      local secret_file
+      secret_file=$(_get_encrypted_filename "$path")
       local perms
-      perms=$($SECRETS_OCTAL_PERMS_COMMAND "$filename")
+      perms=$($SECRETS_OCTAL_PERMS_COMMAND "$secret_file")
 
-      chmod $perms "$path"
+      echo "# octal_perms_command: $SECRETS_OCTAL_PERMS_COMMAND" >&3
+      echo "# filename is '$filename', path is '$path'" >&3
+      echo "# running: chmod '$perms' '$path'" >&3
+
+      chmod "$perms" "$path"
     fi
 
     counter=$((counter+1))

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -54,11 +54,6 @@ function reveal {
       secret_file=$(_get_encrypted_filename "$path")
       local perms
       perms=$($SECRETS_OCTAL_PERMS_COMMAND "$secret_file")
-
-      echo "# octal_perms_command: $SECRETS_OCTAL_PERMS_COMMAND" >&3
-      echo "# filename is '$filename', path is '$path'" >&3
-      echo "# running: chmod '$perms' '$path'" >&3
-
       chmod "$perms" "$path"
     fi
 

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -50,14 +50,10 @@ function reveal {
     fi
 
     if [[ "$chmod" == 1 ]]; then
-        local perms
-	perms=$($SECRETS_OCTAL_PERMS_COMMAND "$filename")
+      local perms
+      perms=$($SECRETS_OCTAL_PERMS_COMMAND "$filename")
 
-	echo "# octal_perms_command: $SECRETS_OCTAL_PERMS_COMMAND" >&3
-	echo "# filename is '$filename', path is '$path'" >&3
-	echo "# NOT running: chmod $perms $path" >&3
-
-        #chmod "$perms" "$path"
+      chmod $perms "$path"
     fi
 
     counter=$((counter+1))

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -37,12 +37,12 @@ function teardown {
   [ -f "$encrypted_file" ]
 }
 
-@test "run 'hide' with '-C'" {
+@test "run 'hide' with '-P'" {
 
   # attempt to alter permissions on input file
   chmod o-rwx "$FILE_TO_HIDE"
 
-  run git secret hide -C
+  run git secret hide -P
 
   # Command must execute normally:
   [ "$status" -eq 0 ]

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -57,7 +57,9 @@ function teardown {
   local file_perm   
   secret_perm=$(ls -l "$encrypted_file" | cut -d' ' -f1)    
   file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
-  echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3
+
+  # text sent to file descriptor 3 is 'diagnostic' (debug) output for devs
+  #echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3
 
   [ "$secret_perm" = "$file_perm" ]
 

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -32,9 +32,35 @@ function teardown {
   [ "$status" -eq 0 ]
   [ "$output" = "done. all 1 files are hidden." ]
 
-  # New files should be crated:
+  # New files should be created:
   local encrypted_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
   [ -f "$encrypted_file" ]
+}
+
+@test "run 'hide' with '-C'" {
+
+  # attempt to alter permissions on input file
+  chmod o-rwx "$FILE_TO_HIDE"
+
+  run git secret hide -C
+
+  # Command must execute normally:
+  [ "$status" -eq 0 ]
+  [ "$output" = "done. all 1 files are hidden." ]
+
+  # New files should be created:
+  local encrypted_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
+  [ -f "$encrypted_file" ]
+
+  # permissions should match. We don't have access to SECRETS_OCTAL_PERMS_COMMAND here
+  local secret_perm
+  local file_perm   
+  secret_perm=$(ls -l "$encrypted_file" | cut -d' ' -f1)    
+  file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
+  echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3
+
+  [ "$secret_perm" = "$file_perm" ]
+
 }
 
 @test "run 'hide' from inside subdirectory" {
@@ -101,7 +127,7 @@ function teardown {
   [ "${lines[0]}" = "done. all 1 files are hidden." ]
   [ "${lines[1]}" = "cleaning up..." ]
 
-  # New files should be crated:
+  # New files should be created:
   local encrypted_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
   [ -f "$encrypted_file" ]
 }
@@ -130,7 +156,7 @@ function teardown {
   # no changes should occur to path_mappings files
   cmp -s "${path_mappings}" "${path_mappings}.bak"
 
-  # New files should be crated:
+  # New files should be created:
   local encrypted_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
   [ -f "$encrypted_file" ]
 }

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -58,7 +58,7 @@ function teardown {
   secret_perm=$(ls -l "$encrypted_file" | cut -d' ' -f1)    
   file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
 
-  # text sent to file descriptor 3 is 'diagnostic' (debug) output for devs
+  # text prefixed with '# ' and sent to file descriptor 3 is 'diagnostic' (debug) output for devs
   #echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3
 
   [ "$secret_perm" = "$file_perm" ]

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -67,8 +67,8 @@ function teardown {
 
   [ "$status" -eq 0 ]
 
-  local perm1
-  local perm2
+  local secret_perm
+  local file_perm
   secret_perm=$(ls -l "$FILE_TO_HIDE".secret | cut -d' ' -f1)
   file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
   echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -55,7 +55,7 @@ function teardown {
 }
 
 
-@test "run 'reveal' with '-C'" {
+@test "run 'reveal' with '-P'" {
   rm "$FILE_TO_HIDE"
 
   local password=$(test_user_password "$TEST_DEFAULT_USER")
@@ -63,7 +63,7 @@ function teardown {
   local secret_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
   chmod o-rwx "$secret_file"
 
-  run git secret reveal -C -d "$TEST_GPG_HOMEDIR" -p "$password"
+  run git secret reveal -P -d "$TEST_GPG_HOMEDIR" -p "$password"
 
   [ "$status" -eq 0 ]
 

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -55,6 +55,16 @@ function teardown {
 }
 
 
+@test "run 'reveal' with '-c'" {
+  rm "$FILE_TO_HIDE"
+
+  local password=$(test_user_password "$TEST_DEFAULT_USER")
+  run git secret reveal -c -d "$TEST_GPG_HOMEDIR" -p "$password"
+
+  [ "$status" -eq 0 ]
+  [ -f "$FILE_TO_HIDE" ]
+}
+
 @test "run 'reveal' with wrong password" {
   rm "$FILE_TO_HIDE"
 

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -72,7 +72,7 @@ function teardown {
   secret_perm=$(ls -l "$FILE_TO_HIDE".secret | cut -d' ' -f1)
   file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
 
-  # text sent to file descriptor 3 is 'diagnostic' (debug) output for devs
+  # text prefixed with '# ' and sent to file descriptor 3 is 'diagnostic' (debug) output for devs
   #echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3    
 
   [ "$secret_perm" = "$file_perm" ]

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -62,6 +62,15 @@ function teardown {
   run git secret reveal -c -d "$TEST_GPG_HOMEDIR" -p "$password"
 
   [ "$status" -eq 0 ]
+
+  local perm1
+  local perm2
+  perm1=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
+  perm2=$(ls -l "$FILE_TO_HIDE".secret | cut -d' ' -f1)
+  echo "# perm1: $perm1, perm2: $perm2" >&3
+
+  [ "$perm1" = "$perm2" ]
+
   [ -f "$FILE_TO_HIDE" ]
 }
 

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -59,17 +59,21 @@ function teardown {
   rm "$FILE_TO_HIDE"
 
   local password=$(test_user_password "$TEST_DEFAULT_USER")
+
+  local secret_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
+  chmod o-rwx "$secret_file"
+
   run git secret reveal -c -d "$TEST_GPG_HOMEDIR" -p "$password"
 
   [ "$status" -eq 0 ]
 
   local perm1
   local perm2
-  perm1=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
-  perm2=$(ls -l "$FILE_TO_HIDE".secret | cut -d' ' -f1)
-  echo "# perm1: $perm1, perm2: $perm2" >&3
+  secret_perm=$(ls -l "$FILE_TO_HIDE".secret | cut -d' ' -f1)
+  file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
+  echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3
 
-  [ "$perm1" = "$perm2" ]
+  [ "$secret_perm" = "$file_perm" ]
 
   [ -f "$FILE_TO_HIDE" ]
 }

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -71,7 +71,9 @@ function teardown {
   local file_perm
   secret_perm=$(ls -l "$FILE_TO_HIDE".secret | cut -d' ' -f1)
   file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
-  echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3
+
+  # text sent to file descriptor 3 is 'diagnostic' (debug) output for devs
+  #echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3    
 
   [ "$secret_perm" = "$file_perm" ]
 

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -55,7 +55,7 @@ function teardown {
 }
 
 
-@test "run 'reveal' with '-c'" {
+@test "run 'reveal' with '-C'" {
   rm "$FILE_TO_HIDE"
 
   local password=$(test_user_password "$TEST_DEFAULT_USER")
@@ -63,7 +63,7 @@ function teardown {
   local secret_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
   chmod o-rwx "$secret_file"
 
-  run git secret reveal -c -d "$TEST_GPG_HOMEDIR" -p "$password"
+  run git secret reveal -C -d "$TEST_GPG_HOMEDIR" -p "$password"
 
   [ "$status" -eq 0 ]
 


### PR DESCRIPTION
For #172. This adds a -P option to 'git secret reveal' like cp's -p (preserve) option.

(-p is already used for 'password' by git-secret)

Suggestions on code changes or specific tests to add welcome.

@sobolevn @gthank  @simbo1905