### PR TITLE
Allow per-command configuration of custom secrets dir

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Folders:
-_SECRETS_DIR=".gitsecret"
+_SECRETS_DIR=${SECRETS_DIR:-".gitsecret"}
 _SECRETS_DIR_KEYS="${_SECRETS_DIR}/keys"
 _SECRETS_DIR_PATHS="${_SECRETS_DIR}/paths"
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Allow per-command configuration of custom secrets dir

Typical use case is when you want different people to have access
to some files and other people access to other different files.

eg.
`SECRETS_DIR=.gitsecret2 git secret init`
`SECRETS_DIR=.gitsecret2 git secret hide`