### PR TITLE
Fixes for new shellcheck error SC2236

### DIFF
--- a/.ci/before_deploy.sh
+++ b/.ci/before_deploy.sh
@@ -8,7 +8,7 @@ if [[ "$GITSECRET_DIST" == "rpm" ]]; then
 fi
 
 # if not null GITSECRET_DIST
-if [[ ! -z "$GITSECRET_DIST" ]]; then
+if [[ -n "$GITSECRET_DIST" ]]; then
   # When making a non-container build, this step will generate
   # proper manifest files:
   make "deploy-$GITSECRET_DIST";

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -454,13 +454,13 @@ function _find_and_clean_formatted {
   local verbose=${2:-""} # can be empty or should be equal to "v"
   local message=${3:-"cleaning:"} # can be any string
 
-  if [[ ! -z "$verbose" ]]; then
+  if [[ -n "$verbose" ]]; then
     echo && echo "$message"
   fi
 
   _find_and_clean "$pattern" "$verbose"
 
-  if [[ ! -z "$verbose" ]]; then
+  if [[ -n "$verbose" ]]; then
     echo
   fi
 }
@@ -623,7 +623,7 @@ function _decrypt {
     args+=( "--yes" )
   fi
 
-  if [[ ! -z "$homedir" ]]; then
+  if [[ -n "$homedir" ]]; then
     args+=( "--homedir" "$homedir" )
   fi
 
@@ -632,7 +632,7 @@ function _decrypt {
   fi
 
   local exit_code
-  if [[ ! -z "$passphrase" ]]; then
+  if [[ -n "$passphrase" ]]; then
     echo "$passphrase" | $SECRETS_GPG_COMMAND "${args[@]}" --quiet --batch --yes --no-tty --passphrase-fd 0 \
       "$encrypted_filename"
     exit_code=$?

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -44,7 +44,7 @@ function changes {
     if [[ ! -f "$encrypted_filename" ]]; then
         _abort "cannot find encrypted version of file: $filename"
     fi
-    if [[ ! -z "$normalized_path" ]]; then
+    if [[ -n "$normalized_path" ]]; then
       path=$(_append_root_path "$normalized_path")
     else
       # Path was already normalized

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -34,7 +34,7 @@ function _optional_delete {
     path_mappings=$(_get_secrets_dir_paths_mapping)
 
     # We use custom formatting here:
-    if [[ ! -z "$verbose" ]]; then
+    if [[ -n "$verbose" ]]; then
       echo && echo 'removing unencrypted files:'
     fi
 
@@ -45,7 +45,7 @@ function _optional_delete {
       _find_and_clean "*$filename" "$verbose"
     done < "$path_mappings"
 
-    if [[ ! -z "$verbose" ]]; then
+    if [[ -n "$verbose" ]]; then
       echo
     fi
   fi


### PR DESCRIPTION
use '-n', not '! -z', as per shellcheck SC2236 
<https://github.com/koalaman/shellcheck/wiki/SC2236>

Seeing this new shellcheck error at (for example): 
<https://travis-ci.org/sobolevn/git-secret/jobs/425890462#L1215>

(The test claims to ignore the failure but then the lint/shellcheck test fails anyway, see
<https://travis-ci.org/sobolevn/git-secret/jobs/425890462#L1357> ).