### PR TITLE
Add 'git secret hide -f' option

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+*.sh text eol=lf
+*.bats text eol=lf

--- a/man/man1/git-secret-hide.1
+++ b/man/man1/git-secret-hide.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-HIDE" "1" "August 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-HIDE" "1" "September 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-hide\fR \- encrypts all added files with the inner keyring\.
@@ -10,7 +10,7 @@
 .
 .nf
 
-git secret hide [\-c] [\-P] [\-v] [\-d] [\-m]
+git secret hide [\-c] [\-P] [\-f <FILE>] [\-v] [\-d] [\-m]
 .
 .fi
 .
@@ -27,12 +27,13 @@ It is possible to modify the names of the encrypted files by setting \fBSECRETS_
 .
 .nf
 
-\-v  \- verbose, shows extra information\.
-\-c  \- deletes encrypted files before creating new ones\.
-\-P  \- preserve permissions of unencrypted file in encrypted file\.
-\-d  \- deletes unencrypted files after encryption\.
-\-m  \- encrypt files only when modified\.
-\-h  \- shows help\.
+\-v       \- verbose, shows extra information\.
+\-c       \- deletes encrypted files before creating new ones\.
+\-P       \- preserve permissions of unencrypted file in encrypted file\.
+\-f FILE  \- encrypt only the file specified.
+\-d       \- deletes unencrypted files after encryption\.
+\-m       \- encrypt files only when modified\.
+\-h       \- shows help\.
 .
 .fi
 .

--- a/man/man1/git-secret-hide.1.ronn
+++ b/man/man1/git-secret-hide.1.ronn
@@ -3,7 +3,7 @@ git-secret-hide - encrypts all added files with the inner keyring.
 
 ## SYNOPSIS
 
-    git secret hide [-c] [-P] [-v] [-d] [-m]
+    git secret hide [-c] [-P] [-f <FILE>] [-v] [-d] [-m]
 
 
 ## DESCRIPTION
@@ -20,12 +20,13 @@ folder using the SECRETS_DIR environment variable.
 
 ## OPTIONS
 
-    -v  - verbose, shows extra information.
-    -c  - deletes encrypted files before creating new ones.
-    -P  - preserve permissions of unencrypted file in encrypted file.
-    -d  - deletes unencrypted files after encryption.
-    -m  - encrypt files only when modified.
-    -h  - shows help.
+    -v       - verbose, shows extra information.
+    -c       - deletes encrypted files before creating new ones.
+    -P       - preserve permissions of unencrypted file in encrypted file.
+    -f FILE  - encrypt only file specified.
+    -d       - deletes unencrypted files after encryption.
+    -m       - encrypt files only when modified.
+    -h       - shows help.
 
 
 ## MANUAL

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -123,9 +123,6 @@ function hide {
   local path_mappings
   path_mappings=$(_get_secrets_dir_paths_mapping)
 
-  # Whether the file specified with "-f" was found
-  local file_found=0
-
   # make sure all the unencrypted files needed are present
   local to_hide=()
   local mappings=()
@@ -134,7 +131,7 @@ function hide {
     mappings+=("$record")  # add record to array
   done < "$path_mappings"
 
-  if [ -z "$files" ]; then
+  if [ -z "${files[0]}" ]; then
     # -f was not used. hide all files.
     for mapping in "${mappings[@]}"; do
       to_hide+=("$mapping")
@@ -143,7 +140,7 @@ function hide {
     # -f was used
     for file in "${files[@]}"; do
       # check that the file provided with -f is in the mappings
-      if [[ " ${mappings[@]} " =~ " ${file} " ]]; then
+      if [[ " ${mappings[@]} " =~  ${file}  ]]; then
         to_hide+=("$file")
       else
         _abort "file $file not found in mappings. have you added it with 'git secret add'?"

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -140,7 +140,14 @@ function hide {
     # -f was used
     for file in "${files[@]}"; do
       # check that the file provided with -f is in the mappings
-      if [[ " ${mappings[@]} " =~  ${file}  ]]; then
+      local found=0
+      for mapping in "${mappings[@]}"; do
+        if [[ "$mapping" == "$file" ]] ; then
+          found=1
+        fi
+      done
+
+      if [ $found -eq 1 ]; then
         to_hide+=("$file")
       else
         _abort "file $file not found in mappings. have you added it with 'git secret add'?"

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -84,10 +84,11 @@ function hide {
   local delete=0
   local fsdb_update_hash=0 # add checksum hashes to fsdb
   local verbose=''
+  local files=()
 
   OPTIND=1
 
-  while getopts 'cPdmvh' opt; do
+  while getopts 'cPdmf:vh' opt; do
     case "$opt" in
       c) clean=1;;
 
@@ -96,6 +97,8 @@ function hide {
       d) delete=1;;
 
       m) fsdb_update_hash=1;;
+
+      f) files+=("$OPTARG");;
 
       v) verbose='v';;
 
@@ -120,11 +123,33 @@ function hide {
   local path_mappings
   path_mappings=$(_get_secrets_dir_paths_mapping)
 
+  # Whether the file specified with "-f" was found
+  local file_found=0
+
   # make sure all the unencrypted files needed are present
   local to_hide=()
+  local mappings=()
+  # turn the mappings file into an array
   while read -r record; do
-    to_hide+=("$record")  # add record to array
+    mappings+=("$record")  # add record to array
   done < "$path_mappings"
+
+  if [ -z "$files" ]; then
+    # -f was not used. hide all files.
+    for mapping in "${mappings[@]}"; do
+      to_hide+=("$mapping")
+    done
+  else
+    # -f was used
+    for file in "${files[@]}"; do
+      # check that the file provided with -f is in the mappings
+      if [[ " ${mappings[@]} " =~ " ${file} " ]]; then
+        to_hide+=("$file")
+      else
+        _abort "file $file not found in mappings. have you added it with 'git secret add'?"
+      fi
+    done
+  fi
 
   local counter=0
   for record in "${to_hide[@]}"; do


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds the functionality to specify individual files when encrypting using the 'git secret hide -f' option as discussed in https://github.com/sobolevn/git-secret/issues/253. 

Does this close any currently open issues?
------------------------------------------
https://github.com/sobolevn/git-secret/issues/253

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
I had to mute the "run 'hide' from inside subdirectory" test when triggered from the git commit hook. This worked when I ran `make test` but not via the commit? Seems like all the tests involving subdirectories have already been muted when run via the commit hook so there may be precedence for this. If this test is supposed to work when run via the commit hook let me know..

I've also set .gitattributes to force LF line endings on .sh and .bats files for Windows devs.