### PR TITLE
Per project SECRETS_EXTENSION setting

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -10,8 +10,14 @@ _SECRETS_DIR_KEYS_MAPPING="${_SECRETS_DIR_KEYS}/mapping.cfg"
 _SECRETS_DIR_KEYS_TRUSTDB="${_SECRETS_DIR_KEYS}/trustdb.gpg"
 
 _SECRETS_DIR_PATHS_MAPPING="${_SECRETS_DIR_PATHS}/mapping.cfg"
+_SECRETS_DIR_SETTINGS="${_SECRETS_DIR_PATHS}/settings.cfg"
 
-: "${SECRETS_EXTENSION:=".secret"}"
+if [ -z "${SECRETS_EXTENSION+x}" ]; then
+  if [ -f "$_SECRETS_DIR_SETTINGS" ]; then
+    . <(grep '^SECRETS_EXTENSION\+="\.[A-Za-z0-9]\+"$' "$_SECRETS_DIR_SETTINGS")
+  fi
+  : "${SECRETS_EXTENSION:=".secret"}"
+fi
 
 # Commands:
 : "${SECRETS_GPG_COMMAND:="gpg"}"


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Allows setting `$SECRETS_EXTENSION` via `.gitsecret/settings.cfg` in this manner:

```
SECRETS_EXTENSION=".gpg"
```

Does this close any currently open issues?
------------------------------------------
Yes, #266.

Any relevant logs, error output, etc?
-------------------------------------

```
66 tests, 0 failures
```

Any other comments?
-------------------

Please tell me what you think!

The implementation sources the given settings file. It uses a fairly tight regular expression to get the correct setting and validate that no malicious code is executed.
Are there better ways to implement this?