### PR TITLE
only increment count of hidden files for hidden files

### DIFF
--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -169,11 +169,13 @@ function hide {
           # if gpg can't encrypt a file we asked it to, that's an error unless in force_continue mode.
           _warn_or_abort "problem encrypting file with gpg: exit code $exit_code: $filename" "$exit_code" "$force_continue"
         fi
-  
-        if [[ "$preserve" == 1 ]] && [[ -f "$output_path" ]]; then
-          local perms
-          perms=$($SECRETS_OCTAL_PERMS_COMMAND "$input_path")
-          chmod "$perms" "$output_path"
+        if [[ -f "$output_path" ]]; then
+          counter=$((counter+1))
+          if [[ "$preserve" == 1 ]]; then
+            local perms
+            perms=$($SECRETS_OCTAL_PERMS_COMMAND "$input_path")
+            chmod "$perms" "$output_path"
+          fi
         fi
 
   
@@ -183,7 +185,6 @@ function hide {
         # Update file hash if required in fsdb
         [[ "$fsdb_update_hash" -gt 0 ]] && \
           _optional_fsdb_update_hash "$key" "$hash"
-        counter=$((counter+1))
       fi
     fi
   done


### PR DESCRIPTION
In #280, we noticed that if a file can't be hidden because of a key problem, git-secret pretends (in the summary count) that the file was hidden anyway. This PR fixes this issue.

Now we only show the count of how many files were actually hidden.