### PR TITLE
WIP: test with expired key, add 'whoknows -l'

### DIFF
--- a/man/man1/git-secret-hide.1
+++ b/man/man1/git-secret-hide.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-HIDE" "1" "September 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-HIDE" "1" "October 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-hide\fR \- encrypts all added files with the inner keyring\.

--- a/man/man1/git-secret-reveal.1
+++ b/man/man1/git-secret-reveal.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REVEAL" "1" "September 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-REVEAL" "1" "October 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-reveal\fR \- decrypts all added files\.

--- a/man/man1/git-secret-whoknows.1
+++ b/man/man1/git-secret-whoknows.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-WHOKNOWS" "1" "August 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-WHOKNOWS" "1" "December 2018" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-whoknows\fR \- prints email\-labels for each key in the keyring\.
@@ -15,12 +15,13 @@ git secret whoknows
 .fi
 .
 .SH "DESCRIPTION"
-\fBgit\-secret\-whoknows\fR prints list of email addresses which are used as labels for currently public keys added to the local keyring\.
+\fBgit\-secret\-whoknows\fR prints list of email addresses whose keys are allowed to access the secrets in this repo\.
 .
 .SH "OPTIONS"
 .
 .nf
 
+\-l  \- \'long\' output, shows key expiration dates\.
 \-h  \- shows this help\.
 .
 .fi

--- a/man/man1/git-secret-whoknows.1.ronn
+++ b/man/man1/git-secret-whoknows.1.ronn
@@ -7,11 +7,12 @@ git-secret-whoknows - prints email-labels for each key in the keyring.
 
 
 ## DESCRIPTION
-`git-secret-whoknows` prints list of email addresses which are used as labels for currently public keys added to the local keyring.
+`git-secret-whoknows` prints list of email addresses whose keys are allowed to access the secrets in this repo.
 
 
 ## OPTIONS
 
+    -l  - 'long' output, shows key expiration dates.
     -h  - shows this help.
 
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -716,6 +716,8 @@ function _decrypt {
     args+=( "--pinentry-mode" "loopback" )
   fi
 
+  set +e   # disable 'set -e' so we can capture exit_code
+
   #echo "# gpg passphrase: $passphrase" >&3
   local exit_code
   if [[ -n "$passphrase" ]]; then
@@ -726,6 +728,9 @@ function _decrypt {
     $SECRETS_GPG_COMMAND "${args[@]}" "--quiet" "$encrypted_filename"
     exit_code=$?
   fi
+
+  set -e  # re-enable set -e
+
   # note that according to https://github.com/sobolevn/git-secret/issues/238 , 
   # it's possible for gpg to return a 0 exit code but not have decrypted the file
   #echo "# gpg exit code: $exit_code, error_ok: $error_ok" >&3

--- a/src/_utils/_git_secret_tools_freebsd.sh
+++ b/src/_utils/_git_secret_tools_freebsd.sh
@@ -41,7 +41,7 @@ function __epoch_to_date_freebsd {
   if [ -z "$epoch" ]; then
     echo ''
   else
-    local cmd="/bin/date +%F -r $epoch"
+    local cmd="date +%F -r $epoch"
     local datetime
     datetime=$($cmd)
     echo "$datetime"

--- a/src/_utils/_git_secret_tools_freebsd.sh
+++ b/src/_utils/_git_secret_tools_freebsd.sh
@@ -35,3 +35,15 @@ function __get_octal_perms_freebsd {
   #     (without 'L' you get 6 digits like '100644'.)
   echo "$perms"
 }
+
+function __epoch_to_date_freebsd {
+  local epoch=$1;
+  if [ -z "$epoch" ]; then
+    echo ''
+  else
+    local cmd="/bin/date +%F -r $epoch"
+    local datetime
+    datetime=$($cmd)
+    echo "$datetime"
+  fi
+}

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -31,7 +31,7 @@ function __epoch_to_date_linux {
   if [ -z "$epoch" ]; then
     echo ''
   else
-    local cmd="/bin/date +%F -d @$epoch"
+    local cmd="date +%F -d @$epoch"
     local datetime
     datetime=$($cmd)
     echo "$datetime"

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -25,3 +25,15 @@ function __get_octal_perms_linux {
   # a string like '0644'
   echo "$perms"
 }
+
+function __epoch_to_date_linux {
+  local epoch=$1;
+  if [ -z "$epoch" ]; then
+    echo ''
+  else
+    local cmd="/bin/date +%F -d @$epoch"
+    local datetime
+    datetime=$($cmd)
+    echo "$datetime"
+  fi
+}

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -36,7 +36,7 @@ function __epoch_to_date_osx {
     #date -r 234234234 +"%Y-%m-%d"
     local cmd="/bin/date -r $epoch +'%Y-%m-%d'"
     local datetime
-    datetime=$($cmd)
+    datetime=$("$cmd")
     echo "$datetime"
   fi
 }

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -27,3 +27,16 @@ function __get_octal_perms_osx {
   # see _git_secret_tools_freebsd.sh for more about stat's format string
   echo "$perms"
 }
+
+function __epoch_to_date_osx {
+  local epoch=$1;
+  if [ -z "$epoch" ]; then
+    echo ''
+  else
+    local cmd="/bin/date +%F -r $epoch"
+    local datetime
+    datetime=$($cmd)
+    echo "$datetime"
+  fi
+}
+

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -35,7 +35,7 @@ function __epoch_to_date_osx {
   else
     #date -r 234234234 +"%Y-%m-%d"
     local datetime
-    datetime=$(/bin/date -r "$epoch" +'%Y-%m-%d')
+    datetime=$(date -r "$epoch" +'%Y-%m-%d')
     echo "$datetime"
   fi
 }

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -34,9 +34,8 @@ function __epoch_to_date_osx {
     echo ''
   else
     #date -r 234234234 +"%Y-%m-%d"
-    local cmd="/bin/date -r $epoch +'%Y-%m-%d'"
     local datetime
-    datetime=$("$cmd")
+    datetime=$(/bin/date -r $epoch +'%Y-%m-%d')
     echo "$datetime"
   fi
 }

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -35,7 +35,7 @@ function __epoch_to_date_osx {
   else
     #date -r 234234234 +"%Y-%m-%d"
     local datetime
-    datetime=$(/bin/date -r $epoch +'%Y-%m-%d')
+    datetime=$(/bin/date -r "$epoch" +'%Y-%m-%d')
     echo "$datetime"
   fi
 }

--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -33,7 +33,8 @@ function __epoch_to_date_osx {
   if [ -z "$epoch" ]; then
     echo ''
   else
-    local cmd="/bin/date +%F -r $epoch"
+    #date -r 234234234 +"%Y-%m-%d"
+    local cmd="/bin/date -r $epoch +'%Y-%m-%d'"
     local datetime
     datetime=$($cmd)
     echo "$datetime"

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -160,11 +160,17 @@ function hide {
   
       # encrypt file only if required
       if [[ "$fsdb_file_hash" != "$file_hash" ]]; then
+
+        set +e   # disable 'set -e' so we can capture exit_code
+
         # we depend on $recipients being split on whitespace
         # shellcheck disable=SC2086
         $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" "--no-permission-warning" --use-agent --yes --trust-model=always --encrypt \
           $recipients -o "$output_path" "$input_path" > /dev/null 2>&1
         local exit_code=$?
+
+        set -e  # re-enable set -e
+
         if [[ "$exit_code" -ne 0 ]] || [[ ! -f "$output_path" ]]; then
           # if gpg can't encrypt a file we asked it to, that's an error unless in force_continue mode.
           _warn_or_abort "problem encrypting file with gpg: exit code $exit_code: $filename" "$exit_code" "$force_continue"
@@ -177,7 +183,6 @@ function hide {
             chmod "$perms" "$output_path"
           fi
         fi
-
   
         # If -m option was provided, it will update unencrypted file hash
         local key="$filename"

--- a/src/commands/git_secret_whoknows.sh
+++ b/src/commands/git_secret_whoknows.sh
@@ -4,9 +4,12 @@
 function whoknows {
   OPTIND=1
 
-  while getopts "h?" opt; do
+  local long_display=0
+  while getopts "hl?" opt; do
     case "$opt" in
       h) _show_manual_for "whoknows";;
+
+      l) long_display=1;;   # like ls -l
 
       *) _invalid_option_for "whoknows";;
     esac
@@ -18,9 +21,25 @@ function whoknows {
   # Validating, that we have a user:
   _user_required
 
-  local keys
+  local users
 
   # Getting the users from gpg:
-  keys=$(_get_users_in_gitsecret_keyring)
-  echo "$keys"
+  users=$(_get_users_in_gitsecret_keyring)
+  for user in $users; do
+      echo -n "$user"
+
+      if [[ "$long_display" -eq 1 ]]; then
+        local expiration
+        expiration=$(_get_user_key_expiry "$user")
+        if [[ -n "$expiration"  ]]; then
+          local expiration_date
+          expiration_date=$($SECRETS_EPOCH_TO_DATE "$expiration")
+          echo -n " (expires: $expiration_date)"
+        else
+          echo -n " (expires: never)"
+        fi
+      fi
+
+      echo
+  done
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# we don't use set -e, it messes up hide -F and reveal -F error handling
+set -e
 
 function _check_setup {
   # Checking git and secret-plugin setup:

--- a/tests/test_expiration.bats
+++ b/tests/test_expiration.bats
@@ -21,13 +21,51 @@ function teardown {
   FILE_CONTENTS="hidden content юникод"
   set_state_secret_add "$FILE_TO_HIDE" "$FILE_CONTENTS"
 
-  run git secret hide 
+  run git secret hide   
+  # this will fail, because we're using an expired key
 
-  #echo "# output of hide: $output" >&3
-    # output should look like 'abort: problem encrypting file with gpg: exit code 2: space file'
+  echo "# output of hide: $output" >&3
+    # output will look like 'abort: problem encrypting file with gpg: exit code 2: space file'
   #echo "# status of hide: $status" >&3
 
   [ $status -ne 0 ] # we expect failure here. Actual code is 2
 }
 
 
+@test "run 'whoknows -l' on only expired user" {
+  run git secret whoknows -l
+  [ "$status" -eq 0 ]
+
+  # diag output for bats-core
+  echo "# output of 'whoknows -l: $output" >&3
+  echo >&3
+    # output should look like 'abort: problem encrypting file with gpg: exit code 2: space file'
+  #echo "# status of hide: $status" >&3
+
+  # Now test the output, both users should be present:
+  [[ "$output" == *"$TEST_EXPIRED_USER"* ]]
+}
+
+
+
+@test "run 'whoknows -l' on expired and normal user" {
+  install_fixture_key "$TEST_DEFAULT_USER"
+  set_state_secret_tell "$TEST_DEFAULT_USER"
+
+  run git secret whoknows -l
+  [ "$status" -eq 0 ]
+
+  echo $output | sed 's/^/# whoknows -l: /' >&3
+  echo >&3
+
+  # Now test the output, both users should be present:
+  [[ "$output" == *"$TEST_DEFAULT_USER"* ]]
+  [[ "$output" == *"$TEST_EXPIRED_USER"* ]]
+
+  uninstall_fixture_key "$TEST_DEFAULT_USER"
+}
+
+function teardown {
+  uninstall_fixture_key "$TEST_EXPIRED_USER"
+  unset_current_state
+}

--- a/tests/test_expiration.bats
+++ b/tests/test_expiration.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+export TZ="GMT"
+
 load _test_base
 
 function setup {
@@ -43,7 +45,7 @@ function teardown {
   #echo "# status of hide: $status" >&3
 
   # Now test the output, both users should be present:
-  [[ "$output" == *"$TEST_EXPIRED_USER"* ]]
+  [[ "$output" == *"$TEST_EXPIRED_USER (expires: 2018-09-23)"* ]]
 }
 
 
@@ -59,8 +61,8 @@ function teardown {
   echo >&3
 
   # Now test the output, both users should be present:
-  [[ "$output" == *"$TEST_DEFAULT_USER"* ]]
-  [[ "$output" == *"$TEST_EXPIRED_USER"* ]]
+  [[ "$output" == *"$TEST_DEFAULT_USER (expires: never)"* ]]
+  [[ "$output" == *"$TEST_EXPIRED_USER (expires: 2018-09-23)"* ]]
 
   uninstall_fixture_key "$TEST_DEFAULT_USER"
 }

--- a/tests/test_whoknows.bats
+++ b/tests/test_whoknows.bats
@@ -31,6 +31,19 @@ function teardown {
   [[ "$output" == *"$TEST_SECOND_USER"* ]]
 }
 
+@test "run 'whoknows -l'" {
+  run git secret whoknows -l
+  [ "$status" -eq 0 ]
+
+  echo "# output of 'whoknows -l: $output" >&3
+  echo >&3
+    # output should look like 'abort: problem encrypting file with gpg: exit code 2: space file'
+  #echo "# status of hide: $status" >&3
+
+  # Now test the output, both users should be present and without expiration
+  [[ "$output" == *"$TEST_DEFAULT_USER (expires: never)"* ]]
+  [[ "$output" == *"$TEST_SECOND_USER (expires: never)"* ]]
+}
 
 @test "run 'whoknows' in subfolder" {
   if [[ "$BATS_RUNNING_FROM_GIT" -eq 1 ]]; then


### PR DESCRIPTION
Regarding #238 (Git secret ignoring gpg issues with expired public key) 
and #283 (Feature request: better messaging about expired keys)

This PR has code to test for and show data about expired keys:

* adds -l option,  'whoknows -l' to show key expiration dates
* adds docs and tests for `whoknows -l`,
* adds tests for expired keys,
* adds epoch_to_date functions

~~WIP,~~ Input welcome