### PR TITLE
Fixes for 'changes' and trailing newlines, for #291

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -738,5 +738,7 @@ function _decrypt {
     local msg="problem decrypting file with gpg: exit code $exit_code: $filename"
     _warn_or_abort "$msg" "$exit_code" "$error_ok"
   fi
+
+  # at this point the file should be written to disk or output to stdout
 }
 

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -32,9 +32,6 @@ function changes {
   '
 
   for filename in "${filenames[@]}"; do
-    local decrypted
-    local diff_result
-
     local path # absolute path
     local normalized_path # relative to the .git dir
     local encrypted_filename
@@ -55,14 +52,13 @@ function changes {
         _abort "file not found. Consider using 'git secret reveal': $filename"
     fi
 
-    # Now we have all the data required:
-    # now do a three-step because the $() construct strips trailing newlines! See #291
+    # Now we have all the data required to do the last encryption and compare results:
+    # now do a three-step to preserve trailing newlines from the $() construct. See #291
     local decrypted_x
     local exit_code
     local decrypted
     decrypted_x=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase"; echo x$?)
     exit_code=${decrypted_x##*x}
-    echo "# exit code is $exit_code" >&3
     decrypted="${decrypted_x%x*}"
 
 

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -56,13 +56,19 @@ function changes {
     fi
 
     # Now we have all the data required:
-    decrypted=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase")
-    # note that the $() construct strips trailing newlines! See #291
+    # now do a three-step because the $() construct strips trailing newlines! See #291
+    local decrypted_x
+    local exit_code
+    local decrypted
+    decrypted_x=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase"; echo x$?)
+    exit_code=${decrypted_x##*x}
+    echo "# exit code is $exit_code" >&3
+    decrypted="${decrypted_x%x*}"
 
 
     echo "changes in ${path}:"
     # diff the result:
     # we have the '|| true' because `diff` returns error if files differ.
-    diff -u <(echo "$decrypted") "$path" || true
+    diff -u <(echo -n "$decrypted") "$path" || true
   done
 }

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -63,6 +63,8 @@ function changes {
     diff_result=$(diff -u <(echo "$decrypted") "$path") || true
     # we have the '|| true' because `diff` returns 
     # exit code `1` when the files are different.
+    # note that the $() construct here also strips trailing newlines! See #291
+
     echo "changes in ${path}:"
     echo "${diff_result}"
   done

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -59,13 +59,10 @@ function changes {
     decrypted=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase")
     # note that the $() construct strips trailing newlines! See #291
 
-    # Let's diff the result:
-    diff_result=$(diff -u <(echo "$decrypted") "$path") || true
-    # we have the '|| true' because `diff` returns 
-    # exit code `1` when the files are different.
-    # note that the $() construct here also strips trailing newlines! See #291
 
     echo "changes in ${path}:"
-    echo "${diff_result}"
+    # diff the result:
+    # we have the '|| true' because `diff` returns error if files differ.
+    diff -u <(echo "$decrypted") "$path" || true
   done
 }

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -62,6 +62,25 @@ function changes {
     diff_result=$(diff -u <(echo "$decrypted") "$path") || true
     # There was a bug in the previous version, since `diff` returns
     # exit code `1` when the files are different.
+
+    # if we use echo -n above, then we get an 8 line diff:
+        #  changes in /tmp/space file:                                                                                                                                                                         1/7
+        # --- /dev/fd/63    2018-12-29 07:42:43.335908084 -0500
+        # +++ "/tmp/space file"    2018-12-29 07:42:43.293909389 -0500
+        # @@ -1 +1,2 @@
+        # -hidden content юникод
+        # \ No newline at end of file
+        # +hidden content юникод
+        # +new content
+
+    # if we use 'echo' above, then we get a 6 line diff:
+        # changes in /tmp/space file:                                                                                                                                                                         1/7
+        # --- /dev/fd/63    2018-12-29 07:43:53.323735486 -0500
+        # +++ "/tmp/space file"    2018-12-29 07:43:53.282736757 -0500
+        # @@ -1 +1,2 @@
+        # hidden content юникод
+        # +new content
+
     echo "changes in ${path}:"
     echo "${diff_result}"
   done

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -59,30 +59,10 @@ function changes {
     decrypted=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase")
     # note that the $() construct strips trailing newlines! See #291
 
-    #echo "# path is $path" >&3
     # Let's diff the result:
     diff_result=$(diff -u <(echo "$decrypted") "$path") || true
     # we have the '|| true' because `diff` returns 
     # exit code `1` when the files are different.
-
-    # if we use echo -n above, then we get an 8 line diff:
-        #  changes in /tmp/space file:                                                                                                                                                                         1/7
-        # --- /dev/fd/63    2018-12-29 07:42:43.335908084 -0500
-        # +++ "/tmp/space file"    2018-12-29 07:42:43.293909389 -0500
-        # @@ -1 +1,2 @@
-        # -hidden content юникод
-        # \ No newline at end of file
-        # +hidden content юникод
-        # +new content
-
-    # if we use 'echo' above, then we get a 6 line diff:
-        # changes in /tmp/space file:                                                                                                                                                                         1/7
-        # --- /dev/fd/63    2018-12-29 07:43:53.323735486 -0500
-        # +++ "/tmp/space file"    2018-12-29 07:43:53.282736757 -0500
-        # @@ -1 +1,2 @@
-        # hidden content юникод
-        # +new content
-
     echo "changes in ${path}:"
     echo "${diff_result}"
   done

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -58,8 +58,8 @@ function changes {
     local exit_code_ignored
     local decrypted
     decrypted_x=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase"; echo x$?)
-    exit_code_ignored=${decrypted_x##*x}    # if _decrypt has an error it will _abort()
     decrypted="${decrypted_x%x*}"
+    #exit_code=${decrypted_x##*x}  # exit code ignored, if _decrypt errors it will _abort()
 
 
     echo "changes in ${path}:"

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -53,12 +53,12 @@ function changes {
     fi
 
     # Now we have all the data required to do the last encryption and compare results:
-    # now do a three-step to preserve trailing newlines from the $() construct. See #291
+    # now do a three-step to protect trailing newlines from the $() construct.
     local decrypted_x
-    local exit_code
+    local exit_code_ignored
     local decrypted
     decrypted_x=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase"; echo x$?)
-    exit_code=${decrypted_x##*x}
+    exit_code_ignored=${decrypted_x##*x}    # if _decrypt has an error it will _abort()
     decrypted="${decrypted_x%x*}"
 
 

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -53,18 +53,17 @@ function changes {
     fi
 
     # Now we have all the data required to do the last encryption and compare results:
-    # now do a three-step to protect trailing newlines from the $() construct.
+    # now do a two-step to protect trailing newlines from the $() construct.
     local decrypted_x
-    local exit_code_ignored
     local decrypted
     decrypted_x=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase"; echo x$?)
     decrypted="${decrypted_x%x*}"
-    #exit_code=${decrypted_x##*x}  # exit code ignored, if _decrypt errors it will _abort()
+    # we ignore the exit code because _decrypt will _abort if appropriate.
 
 
     echo "changes in ${path}:"
     # diff the result:
-    # we have the '|| true' because `diff` returns error if files differ.
+    # we have the '|| true' because `diff` returns error code if files differ.
     diff -u <(echo -n "$decrypted") "$path" || true
   done
 }

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -57,10 +57,12 @@ function changes {
 
     # Now we have all the data required:
     decrypted=$(_decrypt "$path" "0" "0" "$homedir" "$passphrase")
+    # note that the $() construct strips trailing newlines! See #291
 
+    #echo "# path is $path" >&3
     # Let's diff the result:
     diff_result=$(diff -u <(echo "$decrypted") "$path") || true
-    # There was a bug in the previous version, since `diff` returns
+    # we have the '|| true' because `diff` returns 
     # exit code `1` when the files are different.
 
     # if we use echo -n above, then we get an 8 line diff:

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -214,8 +214,7 @@ function set_state_secret_tell {
 function set_state_secret_add {
   local filename="$1"
   local content="$2"
-  echo "$content" > "$filename"      # we do not add a newline
-  #echo -e "$content" > "$filename"      # we do add a newline
+  echo "$content" > "$filename"      # we add a newline
   echo "$filename" >> ".gitignore"
 
   git secret add "$filename" > /dev/null 2>&1

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -214,7 +214,8 @@ function set_state_secret_tell {
 function set_state_secret_add {
   local filename="$1"
   local content="$2"
-  echo "$content" > "$filename"
+  echo "$content" > "$filename"      # we do not add a newline
+  #echo -e "$content" > "$filename"      # we do add a newline
   echo "$filename" >> ".gitignore"
 
   git secret add "$filename" > /dev/null 2>&1

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -220,6 +220,15 @@ function set_state_secret_add {
   git secret add "$filename" > /dev/null 2>&1
 }
 
+function set_state_secret_add_without_newline {
+  local filename="$1"
+  local content="$2"
+  echo -n "$content" > "$filename"      # we do not add a newline
+  echo "$filename" >> ".gitignore"
+
+  git secret add "$filename" > /dev/null 2>&1
+}
+
 
 function set_state_secret_hide {
   git secret hide > /dev/null 2>&1

--- a/tests/test_cat.bats
+++ b/tests/test_cat.bats
@@ -33,7 +33,6 @@ function teardown {
   [ "$status" -eq 0 ]
 
   # $output is the output from 'git secret cat' above
-  # note that currently content may differ by a newline (!) - see #291
   [ "$FILE_CONTENTS" == "$output" ]
 }
 

--- a/tests/test_cat.bats
+++ b/tests/test_cat.bats
@@ -33,7 +33,7 @@ function teardown {
   [ "$status" -eq 0 ]
 
   # $output is the output from 'git secret cat' above
-  # note that currently content may differ by a newline
+  # note that currently content may differ by a newline (!) - see #291
   [ "$FILE_CONTENTS" == "$output" ]
 }
 

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -36,7 +36,10 @@ function teardown {
   echo "$output" | sed 's/^/# output: /' >&3
 
   [ "$status" -eq 0 ]
-  [ "$output"  == "changes in /tmp/space file:" ]
+
+  local num_lines=$(echo "$output" | wc -l)
+  echo "# num lines is $num_lines" >&3
+  [[ "num_lines" -eq 1 ]]
 }
 
 

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -29,12 +29,11 @@ function teardown {
   unset_current_state
 }
 
-@test "run 'changes' with no file changed" {
+@test "run 'changes' on one file with no file changed" {
   local password=$(test_user_password "$TEST_DEFAULT_USER")
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
 
-  echo "# output is '$output'" | sed 's/^/# /' >&3
-  echo "# " >&3
+  echo "$output" | sed 's/^/# output: /' >&3
 
   [ "$status" -eq 0 ]
   [ "$output"  == "changes in /tmp/space file:" ]
@@ -49,8 +48,7 @@ function teardown {
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
   [ "$status" -eq 0 ]
 
-  echo "# output is '$output'" | sed 's/^/# /' >&3
-  echo "# " >&3
+  echo "$output" | sed 's/^/# output: /' >&3
 
   # Testing that output has both filename and changes:
   local fullpath=$(_append_root_path "$FILE_TO_HIDE")
@@ -98,11 +96,22 @@ function teardown {
 }
 
 
-@test "run 'changes' without changes" {
+@test "run 'changes' on two files with no file changed" {
   local password=$(test_user_password "$TEST_DEFAULT_USER")
 
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password"
+
+  echo "$output" | sed 's/^/# output: /' >&3
+
   [ "$status" -eq 0 ]
+
+  local num_lines=$(echo "$output" | wc -l)
+  echo "# num lines is $num_lines" >&3
+  [[ "num_lines" -eq 3 ]]
+
+  #[ "$output"  == "changes in *(?)/space file:" ]
+  # on OSX this gets created in a file like 
+  # /private/var/folders/ab/wv4_9xx56hh9k3tebrhdzvwg90000gn/W/space file
 }
 
 

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -29,6 +29,17 @@ function teardown {
   unset_current_state
 }
 
+@test "run 'changes' with no file changed" {
+  local password=$(test_user_password "$TEST_DEFAULT_USER")
+  run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
+
+  echo "# output is '$output'" | sed 's/^/# /' >&3
+  echo "# " >&3
+
+  [ "$status" -eq 0 ]
+  [ "$output"  == "changes in /tmp/space file:" ]
+}
+
 
 @test "run 'changes' with one file changed" {
   local password=$(test_user_password "$TEST_DEFAULT_USER")
@@ -38,10 +49,19 @@ function teardown {
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
   [ "$status" -eq 0 ]
 
+  echo "# output is '$output'" | sed 's/^/# /' >&3
+  echo "# " >&3
+
   # Testing that output has both filename and changes:
   local fullpath=$(_append_root_path "$FILE_TO_HIDE")
   [[ "$output" == *"changes in $fullpath"* ]]
+  [[ "$output" == *"hidden content юникод"* ]]
   [[ "$output" == *"+$new_content"* ]]
+
+  local num_lines=$(echo "$output" | wc -l)
+  echo "# num lines is $num_lines" >&3
+  [[ "num_lines" -eq 6 ]]
+
 }
 
 @test "run 'changes' with source file missing" {

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -35,12 +35,9 @@ function teardown {
   local password=$(test_user_password "$TEST_DEFAULT_USER")
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
 
-  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
-
   [ "$status" -eq 0 ]
 
   local num_lines=$(echo "$output" | wc -l)
-  echo "# '$BATS_TEST_DESCRIPTION': num lines is $num_lines" >&3
   [[ "num_lines" -eq 1 ]]
 }
 
@@ -53,8 +50,6 @@ function teardown {
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
   [ "$status" -eq 0 ]
 
-  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
-
   # Testing that output has both filename and changes:
   local fullpath=$(_append_root_path "$FILE_TO_HIDE")
   [[ "$output" == *"changes in $fullpath"* ]]
@@ -62,7 +57,6 @@ function teardown {
   [[ "$output" == *"+$new_content"* ]]
 
   local num_lines=$(echo "$output" | wc -l)
-  echo "# '$BATS_TEST_DESCRIPTION': num lines is $num_lines" >&3
   [[ "num_lines" -eq 6 ]]
 
 }
@@ -106,12 +100,10 @@ function teardown {
 
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password"
 
-  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 
   [ "$status" -eq 0 ]
 
   local num_lines=$(echo "$output" | wc -l)
-  echo "# '$BATS_TEST_DESCRIPTION': num lines is $num_lines" >&3
   [[ "num_lines" -eq 2 ]]   
 }
 
@@ -126,12 +118,8 @@ function teardown {
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password"
   [ "$status" -eq 0 ]
 
-  #echo "# output is '$output'" >&3
-  #echo "# " >&3
-
   # Testing that output has both filename and changes:
   local fullpath=$(_append_root_path "$FILE_TO_HIDE")
-  #echo "# fullpath is $fullpath" >&3
 
   [[ "$output" == *"changes in $fullpath"* ]]
   [[ "$output" == *"+$new_content"* ]]
@@ -167,20 +155,16 @@ function teardown {
 @test "run 'changes' on file that does not exist" {
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_NON_EXISTANT"
   [ "$status" -ne 0 ]
-  #echo "# $BATS_TEST_DESCRIPTION: output is '$output'" >&3
 }
 
 @test "run 'changes' on one file without newlines" {
   set_state_secret_add_without_newline "$THIRD_FILE_TO_HIDE" "$FILE_CONTENTS"
   set_state_secret_hide
 
-  echo -n "$FILE_CONTENTS" > "$THIRD_FILE_TO_HIDE"  # no newline
-
   local password=$(test_user_password "$TEST_DEFAULT_USER")
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$THIRD_FILE_TO_HIDE"
+  [ "$status" -eq 0 ]
 
   local num_lines=$(echo "$output" | wc -l)
-    
-  [ "$status" -eq 0 ]
-  [[ "num_lines" -eq 1 ]]
+  [[ "$num_lines" -eq 1 ]]
 }

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -38,7 +38,7 @@ function teardown {
   [ "$status" -eq 0 ]
 
   local num_lines=$(echo "$output" | wc -l)
-  [[ "num_lines" -eq 1 ]]
+  [[ "$num_lines" -eq 1 ]]
 }
 
 
@@ -57,7 +57,7 @@ function teardown {
   [[ "$output" == *"+$new_content"* ]]
 
   local num_lines=$(echo "$output" | wc -l)
-  [[ "num_lines" -eq 6 ]]
+  [[ "$num_lines" -eq 6 ]]
 
 }
 
@@ -104,7 +104,7 @@ function teardown {
   [ "$status" -eq 0 ]
 
   local num_lines=$(echo "$output" | wc -l)
-  [[ "num_lines" -eq 2 ]]   
+  [[ "$num_lines" -eq 2 ]]   
 }
 
 

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -110,12 +110,7 @@ function teardown {
 
   local num_lines=$(echo "$output" | wc -l)
   echo "# '$BATS_TEST_DESCRIPTION': num lines is $num_lines" >&3
-  [[ "num_lines" -eq 3 ]]   
-        # should this be two lines instead of three? 
-        # Why the blank second line? we see: 
-        #   output: changes in /tmp/space file:
-        #   output:
-        #   output: changes in /tmp/space file two:
+  [[ "num_lines" -eq 2 ]]   
 }
 
 

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -110,11 +110,12 @@ function teardown {
 
   local num_lines=$(echo "$output" | wc -l)
   echo "# num lines is $num_lines" >&3
-  [[ "num_lines" -eq 3 ]]
-
-  #[ "$output"  == "changes in *(?)/space file:" ]
-  # on OSX this gets created in a file like 
-  # /private/var/folders/ab/wv4_9xx56hh9k3tebrhdzvwg90000gn/W/space file
+  [[ "num_lines" -eq 3 ]]   
+        # should this be two lines instead of three? 
+        # Why the blank second line? we see: 
+        #   output: changes in /tmp/space file:
+        #   output:
+        #   output: changes in /tmp/space file two:
 }
 
 

--- a/tests/test_changes.bats
+++ b/tests/test_changes.bats
@@ -33,12 +33,12 @@ function teardown {
   local password=$(test_user_password "$TEST_DEFAULT_USER")
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
 
-  echo "$output" | sed 's/^/# output: /' >&3
+  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 
   [ "$status" -eq 0 ]
 
   local num_lines=$(echo "$output" | wc -l)
-  echo "# num lines is $num_lines" >&3
+  echo "# '$BATS_TEST_DESCRIPTION': num lines is $num_lines" >&3
   [[ "num_lines" -eq 1 ]]
 }
 
@@ -51,7 +51,7 @@ function teardown {
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
   [ "$status" -eq 0 ]
 
-  echo "$output" | sed 's/^/# output: /' >&3
+  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 
   # Testing that output has both filename and changes:
   local fullpath=$(_append_root_path "$FILE_TO_HIDE")
@@ -60,7 +60,7 @@ function teardown {
   [[ "$output" == *"+$new_content"* ]]
 
   local num_lines=$(echo "$output" | wc -l)
-  echo "# num lines is $num_lines" >&3
+  echo "# '$BATS_TEST_DESCRIPTION': num lines is $num_lines" >&3
   [[ "num_lines" -eq 6 ]]
 
 }
@@ -104,12 +104,12 @@ function teardown {
 
   run git secret changes -d "$TEST_GPG_HOMEDIR" -p "$password"
 
-  echo "$output" | sed 's/^/# output: /' >&3
+  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 
   [ "$status" -eq 0 ]
 
   local num_lines=$(echo "$output" | wc -l)
-  echo "# num lines is $num_lines" >&3
+  echo "# '$BATS_TEST_DESCRIPTION': num lines is $num_lines" >&3
   [[ "num_lines" -eq 3 ]]   
         # should this be two lines instead of three? 
         # Why the blank second line? we see: 

--- a/tests/test_expiration.bats
+++ b/tests/test_expiration.bats
@@ -26,7 +26,7 @@ function teardown {
   run git secret hide   
   # this will fail, because we're using an expired key
 
-  echo "# output of hide: $output" >&3
+  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
     # output will look like 'abort: problem encrypting file with gpg: exit code 2: space file'
   #echo "# status of hide: $status" >&3
 
@@ -39,10 +39,10 @@ function teardown {
   [ "$status" -eq 0 ]
 
   # diag output for bats-core
-  echo "# output of 'whoknows -l: $output" >&3
-  echo >&3
-    # output should look like 'abort: problem encrypting file with gpg: exit code 2: space file'
-  #echo "# status of hide: $status" >&3
+  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
+  # output should look like 'abort: problem encrypting file with gpg: exit code 2: space file'
+  
+  #echo "# $BATS_TEST_DESCRIPTION: $status" >&3
 
   # Now test the output, both users should be present:
   [[ "$output" == *"$TEST_EXPIRED_USER (expires: 2018-09-23)"* ]]
@@ -57,8 +57,7 @@ function teardown {
   run git secret whoknows -l
   [ "$status" -eq 0 ]
 
-  echo $output | sed 's/^/# whoknows -l: /' >&3
-  echo >&3
+  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 
   # Now test the output, both users should be present:
   [[ "$output" == *"$TEST_DEFAULT_USER (expires: never)"* ]]

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -28,7 +28,7 @@ function teardown {
 @test "run 'hide' normally" {
   run git secret hide
 
-  #echo "# run hide normally: output: $output" >&3
+  #echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 
   # Command must execute normally:
   [ "$status" -eq 0 ]
@@ -46,7 +46,7 @@ function teardown {
 
   run git secret hide -P
 
-  #echo "# run hide with -P: output: $output" >&3
+  #echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 
   # Command must execute normally:
   [ "$status" -eq 0 ]
@@ -63,7 +63,7 @@ function teardown {
   file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
 
   # text prefixed with '# ' and sent to file descriptor 3 is 'diagnostic' (debug) output for devs
-  #echo "# secret_perm: $secret_perm, file_perm: $file_perm" >&3
+  #echo "# '$BATS_TEST_DESCRIPTION': $secret_perm, file_perm: $file_perm" >&3
 
   [ "$secret_perm" = "$file_perm" ]
 
@@ -115,7 +115,7 @@ function teardown {
 
   # Now it should hide 2 files:
   run git secret hide
-  #echo "# run hide with multiple files: output: $output" >&3
+  #echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
   [ "$status" -eq 0 ]
   [ "$output" = "done. 2 of 2 files are hidden." ]
 
@@ -145,7 +145,7 @@ function teardown {
   path_mappings=$(_get_secrets_dir_paths_mapping)
   run git secret hide -m
 
-  #echo "# run hide with -m twice: output: $output" >&3
+  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 
   # Command must execute normally:
   [ "$status" -eq 0 ]

--- a/tests/test_whoknows.bats
+++ b/tests/test_whoknows.bats
@@ -35,10 +35,9 @@ function teardown {
   run git secret whoknows -l
   [ "$status" -eq 0 ]
 
-  echo "# output of 'whoknows -l: $output" >&3
-  echo >&3
+  echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
     # output should look like 'abort: problem encrypting file with gpg: exit code 2: space file'
-  #echo "# status of hide: $status" >&3
+  #echo "# '$BATS_TEST_DESCRIPTION' status: $status" >&3
 
   # Now test the output, both users should be present and without expiration
   [[ "$output" == *"$TEST_DEFAULT_USER (expires: never)"* ]]


### PR DESCRIPTION
~~@sobolevn @brandoncssanders  I think issue #291 & PR #292 might not be relevant for git-secret master.~~

~~I cannot reproduce #291 in my tests with git-secret master, (see the test "run 'changes' with no file changed"  in tests/test_changes.bats )~~

~~Also I did some experimenting with #292 and master and I'm not sure it improves things.
(See new comments in src/commands/git_secret_changes.sh]~~

~~Am I missing something? Is there an issue with git-secret changes in master?~~

Edit: This fixes bugs in 'git secret changes' related to trailing newlines in file contents. 
For details see the comments in #291 
