### PR TITLE
fix link to homebrew, update CHANGELOG.md (#310, #311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
+## {{Next Version}}
+
+- Fix link to homebrew's git-secret in README.md (#310)
+- Update CHANGELOG.md to mention fix for #281 in v0.2.5 (#311)
+
 ## Version 0.2.5
 
+- Added notes about packages and for package maintainers (#281)
 - Fix issues with spaces in paths and filenames (#226, #135)
 - Fix issue when 'hide' used in subdir of repo (#230)
 - Fix issues in 'changes' with trailing newlines (#291)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # git-secret
 
-[![Backers on Open Collective](https://opencollective.com/git-secret/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/git-secret/sponsors/badge.svg)](#sponsors) [![Build Status](https://img.shields.io/travis/sobolevn/git-secret/master.svg)](https://travis-ci.org/sobolevn/git-secret) [![Homebrew](https://img.shields.io/homebrew/v/git-secret.svg)](http://braumeister.org/formula/git-secret) [![Bintray deb](https://img.shields.io/bintray/v/sobolevn/deb/git-secret.svg)](https://bintray.com/sobolevn/deb/git-secret/view)
+[![Backers on Open Collective](https://opencollective.com/git-secret/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/git-secret/sponsors/badge.svg)](#sponsors) [![Build Status](https://img.shields.io/travis/sobolevn/git-secret/master.svg)](https://travis-ci.org/sobolevn/git-secret) [![Homebrew](https://img.shields.io/homebrew/v/git-secret.svg)](https://formulae.brew.sh/formula/git-secret) [![Bintray deb](https://img.shields.io/bintray/v/sobolevn/deb/git-secret.svg)](https://bintray.com/sobolevn/deb/git-secret/view)
 
 [![git-secret](https://raw.githubusercontent.com/sobolevn/git-secret/gh-pages/images/git-secret-big.png)](http://git-secret.io/)
 


### PR DESCRIPTION
The correct link is https://formulae.brew.sh/formula/git-secret
not
http://braumeister.org/formula/git-secret