### PR TITLE
use 'git add --all' as per git 2.0

### DIFF
--- a/utils/gh-branch.sh
+++ b/utils/gh-branch.sh
@@ -11,7 +11,7 @@ function update_gh_branch {
   git checkout 'gh-pages'
   make
 
-  git add '_posts'
+  git add --all '_posts'
   git commit -m 'documentation update'
   git checkout "$branch_name"
 }


### PR DESCRIPTION
Otherwise `make build-gh-pages` gives error like

`[gh-pages-add-fix 3150b60] use 'git add --all' as per git 2.0`

(Edit: this occurs even using git `1.8.3.1`)