### PR TITLE
add secret files pattern to .gitignore on init

### DIFF
--- a/src/commands/git_secret_init.sh
+++ b/src/commands/git_secret_init.sh
@@ -74,6 +74,7 @@ function init {
   local random_seed_file
   random_seed_file=".gitsecret/keys/random_seed"
   gitignore_add_pattern "$random_seed_file"
+  gitignore_add_pattern "!*$SECRETS_EXTENSION"
 
   # TODO: git attributes to view diffs
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue
1. Make sure that you open your pull request against the `master` branch
2. Make sure that tests pass
3. Make sure that your code has the same style

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Ensure secret files won't be ignored by git. Running `git secret init` appends a pattern ensuring files ended with `$SECRET_EXTENSION`, i.e. `.secret` won't be ignored by git.

Any other comments?
-------------------
It's common to tell git to ignore files by using wildcards. For instance, if a project has multiple dotenv files it makes sense to add `.env*` to `.gitignore`, however, this would also be covering any secrets starting with `.env`, like `.env.dev.secret`

To fix this, adding `!*.secret` to `.gitignore` ensures files ending in `.secret` won't be ignore by git, as long as this definition is after the previous wildcard setup, that is, closer to the end of the file.

Given that `git secret init` already appends the random seed path to `.gitignore`, it only makes sense that it would also tell git to not ignore secret files. 