### PR TITLE
Respect secrets dir on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Change 'init' to never ignore .secret files (#362)
 - Add text explaining git-secret Style Guide and Development Philosophy
 - Spelling fixes
+- Fix re: SECRETS_DIR in 'init' and SECRETS_EXTENSION in test_reveal.bats (#364)
 
 ## Version 0.2.5
 

--- a/man/man1/git-secret-init.1
+++ b/man/man1/git-secret-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-INIT" "1" "August 2018" "sobolevn" "git-secret"
+.TH "GIT\-SECRET\-INIT" "1" "February 2019" "sobolevn" "git-secret"
 .
 .SH "NAME"
 \fBgit\-secret\-init\fR \- initializes git\-secret repository\.
@@ -18,7 +18,10 @@ git secret init
 \fBgit\-secret\-init\fR should be run inside a \fBgit\fR repo to set up the \.gitsecret directory and initialize the repo for git\-secret\. Until repository is initialized with \fBgit secret init\fR, all other \fBgit\-secret\fR commands are unavailable\.
 .
 .P
-(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder using the SECRETS_DIR environment variable\.
+If a \.gitsecret directory already exists, \fBgit\-secret\-init\fR exits without making any changes\. Otherwise, a \.gitsecret directory is created with appropriate sub\-directories, and patterns to ignore git\-secret\'s \fBrandom_seed_file\fR and not ignore \fB\.secret\fR files are added to \fB\.gitignore\fR\.
+.
+.P
+(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder with the SECRETS_DIR environment variable, and changing the extension git\-secret uses for secret files with the SECRETS_EXTENSION environment variable\.
 .
 .SH "OPTIONS"
 .

--- a/man/man1/git-secret-init.1.ronn
+++ b/man/man1/git-secret-init.1.ronn
@@ -10,8 +10,14 @@ git-secret-init - initializes git-secret repository.
 `git-secret-init` should be run inside a `git` repo to set up the .gitsecret directory and initialize the repo for git-secret.
 Until repository is initialized with `git secret init`, all other `git-secret` commands are unavailable.
 
+If a .gitsecret directory already exists, `git-secret-init` exits without making any changes.
+Otherwise, a .gitsecret directory is created with appropriate sub-directories,
+and patterns to ignore git-secret's `random_seed_file`
+and not ignore `.secret` files are added to `.gitignore`.  
+
 (See [git-secret(7)](http://git-secret.io/git-secret) for information about renaming the .gitsecret
-folder using the SECRETS_DIR environment variable.
+folder with the SECRETS_DIR environment variable, and changing the extension git-secret uses for secret files
+with the SECRETS_EXTENSION environment variable.
 
 
 ## OPTIONS

--- a/src/commands/git_secret_init.sh
+++ b/src/commands/git_secret_init.sh
@@ -72,7 +72,7 @@ function init {
   echo "'$git_secret_dir/' created."
 
   local random_seed_file
-  random_seed_file=".gitsecret/keys/random_seed"
+  random_seed_file="${_SECRETS_DIR}/keys/random_seed"
   gitignore_add_pattern "$random_seed_file"
   gitignore_add_pattern "!*$SECRETS_EXTENSION"
 

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -33,6 +33,8 @@ function teardown {
   [ "$status" -eq 0 ]
 
   [[ -d "${_SECRETS_DIR}" ]]
+  echo ${_SECRETS_DIR}/* | sed "s/^/# '$BATS_TEST_DESCRIPTION' contents of secrets dir: /" >&3
+  cat .gitignore | sed "s/^/# '$BATS_TEST_DESCRIPTION' contents of .gitignore: /" >&3
 }
 
 

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -33,8 +33,6 @@ function teardown {
   [ "$status" -eq 0 ]
 
   [[ -d "${_SECRETS_DIR}" ]]
-  echo ${_SECRETS_DIR}/* | sed "s/^/# '$BATS_TEST_DESCRIPTION' contents of secrets dir: /" >&3
-  cat .gitignore | sed "s/^/# '$BATS_TEST_DESCRIPTION' contents of .gitignore: /" >&3
 }
 
 

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -69,7 +69,7 @@ function teardown {
 
   local secret_perm
   local file_perm
-  secret_perm=$(ls -l "$FILE_TO_HIDE".secret | cut -d' ' -f1)
+  secret_perm=$(ls -l "$FILE_TO_HIDE$SECRETS_EXTENSION" | cut -d' ' -f1)
   file_perm=$(ls -l "$FILE_TO_HIDE" | cut -d' ' -f1)
 
   # text prefixed with '# ' and sent to file descriptor 3 is 'diagnostic' (debug) output for devs

--- a/utils/tests.sh
+++ b/utils/tests.sh
@@ -7,7 +7,9 @@ set -e
 # Running all the bats-tests in a dir with spaces:
 cd "${SECRET_PROJECT_ROOT}"; rm -rf 'tempdir with spaces'; mkdir 'tempdir with spaces'; cd 'tempdir with spaces';
 
+# test with non-standard SECRETS_DIR (normally .gitsecret) and SECRETS_EXTENSION (normally .secret)
 export SECRETS_DIR=.gitsecret-testdir
+export SECRETS_EXTENSION=.secret2
 
 # bats expects diagnostic lines to be sent to fd 3, matching regex '^ #' (IE, like: `echo '# message here' >&3`)
 # bats ... 3>&1 shows diagnostic output when errors occur.


### PR DESCRIPTION
closes #364 

also sets SECRETS_EXTENSION to `.secret2` for testing, and fixes a test using that variable in `test_reveal.bats`