### PR TITLE
Add sed regex to _get_git_root_path that changes <driveletter>:/ to /…

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -141,7 +141,7 @@ function _os_based {
 
 function _clean_path {
   # This function transforms windows paths to *nix paths
-  echo $1 | sed 's#^\([a-zA-Z]\):/#/\1/#'
+  echo "$1" | sed 's#^\([a-zA-Z]\):/#/\1/#'
 }
 
 function _set_config {
@@ -356,7 +356,7 @@ function _get_git_root_path {
   # since `.gitsecret` (or value set by SECRETS_DIR env var) must be on the same level.
 
   local result
-  result=$(_clean_path `git rev-parse --show-toplevel`)
+  result=$(_clean_path "$(git rev-parse --show-toplevel)")
   echo "$result"
 }
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -141,6 +141,7 @@ function _os_based {
 
 function _clean_path {
   # This function transforms windows paths to *nix paths
+  # shellcheck disable=SC2001
   echo "$1" | sed 's#^\([a-zA-Z]\):/#/\1/#'
 }
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -351,7 +351,7 @@ function _get_git_root_path {
   # since `.gitsecret` (or value set by SECRETS_DIR env var) must be on the same level.
 
   local result
-  result=$(git rev-parse --show-toplevel)
+  result=$(git rev-parse --show-toplevel | sed 's#^\([a-zA-Z]\):/#/\1/#')
   echo "$result"
 }
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -139,6 +139,11 @@ function _os_based {
 
 # File System:
 
+function _clean_path {
+  # This function transforms windows paths to *nix paths
+  echo $1 | sed 's#^\([a-zA-Z]\):/#/\1/#'
+}
+
 function _set_config {
   # This function creates a line in the config, or alters it.
 
@@ -351,7 +356,7 @@ function _get_git_root_path {
   # since `.gitsecret` (or value set by SECRETS_DIR env var) must be on the same level.
 
   local result
-  result=$(git rev-parse --show-toplevel | sed 's#^\([a-zA-Z]\):/#/\1/#')
+  result=$(_clean_path `git rev-parse --show-toplevel`)
   echo "$result"
 }
 

--- a/src/commands/git_secret_cat.sh
+++ b/src/commands/git_secret_cat.sh
@@ -13,7 +13,7 @@ function cat {
 
       p) passphrase=$OPTARG;;
 
-      d) homedir=$OPTARG;;
+      d) homedir=$(_clean_path $OPTARG);;
 
       *) _invalid_option_for 'cat';;
     esac

--- a/src/commands/git_secret_cat.sh
+++ b/src/commands/git_secret_cat.sh
@@ -13,7 +13,7 @@ function cat {
 
       p) passphrase=$OPTARG;;
 
-      d) homedir=$(_clean_path $OPTARG);;
+      d) homedir=$(_clean_path "$OPTARG");;
 
       *) _invalid_option_for 'cat';;
     esac

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -11,7 +11,7 @@ function changes {
 
       p) passphrase=$OPTARG;;
 
-      d) homedir=$OPTARG;;
+      d) homedir=$(_clean_path $OPTARG);;
 
       *) _invalid_option_for 'changes';;
     esac

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -11,7 +11,7 @@ function changes {
 
       p) passphrase=$OPTARG;;
 
-      d) homedir=$(_clean_path $OPTARG);;
+      d) homedir=$(_clean_path "$OPTARG");;
 
       *) _invalid_option_for 'changes';;
     esac

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -22,7 +22,7 @@ function reveal {
 
       p) passphrase=$OPTARG;;
 
-      d) homedir=$OPTARG;;
+      d) homedir=$(_clean_path $OPTARG);;
 
       *) _invalid_option_for 'reveal';;
     esac

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -22,7 +22,7 @@ function reveal {
 
       p) passphrase=$OPTARG;;
 
-      d) homedir=$(_clean_path $OPTARG);;
+      d) homedir=$(_clean_path "$OPTARG");;
 
       *) _invalid_option_for 'reveal';;
     esac

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -35,7 +35,7 @@ function tell {
 
       m) self_email=1;;
 
-      d) homedir=$(_clean_path $OPTARG);;
+      d) homedir=$(_clean_path "$OPTARG");;
 
       *) _invalid_option_for 'tell';;
     esac

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -35,7 +35,7 @@ function tell {
 
       m) self_email=1;;
 
-      d) homedir=$OPTARG;;
+      d) homedir=$(_clean_path $OPTARG);;
 
       *) _invalid_option_for 'tell';;
     esac


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Under git for windows `git rev-parse --show-toplevel` outputs paths in the form **C:/path/to/repo**. This breaks gpg with the --homedir set to this path as no leading slash is considered a relative path and stacks the argument with current directory, leading gpg to trying to access **/c/path/to/repo/C:/path/to/repo/.gitsecret**.
The suggested change fixes this by patching the `_get_git_root_path` to change the driveletter part to an absolute *nix path, which will then work with `gpg --homedir`

Does this close any currently open issues?
------------------------------------------
No open issues. Did PR instead of submitting one.
