### PR TITLE
have lint target run shellcheck over tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add text explaining git-secret Style Guide and Development Philosophy
 - Upgrade bats-core to v1.1.0
 - Spelling fixes
+- Use Shellcheck on tests/ files, changes for Shellcheck in tests/ (#368)
 
 ## Version 0.2.5
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ develop: clean build install-hooks
 
 .PHONY: lint
 lint:
-	@find src utils -type f -name '*.sh' -print0 | xargs -0 -I {} shellcheck {}
+	@find src utils tests -type f -name '*.sh' -print0 | xargs -0 -I {} shellcheck {}
 
 #
 # Packaging:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ develop: clean build install-hooks
 
 .PHONY: lint
 lint:
-	@find src utils tests -type f -name '*.sh' -print0 | xargs -0 -I {} shellcheck {}
+	find src utils -type f -name '*.sh' -print0 | xargs -0 -I {} shellcheck {}
+	find tests -type f -name '*.bats' -o -name '*.bash' -print0 | xargs -0 -I {} shellcheck {}
 
 #
 # Packaging:

--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ develop: clean build install-hooks
 
 .PHONY: lint
 lint:
-	find src utils -type f -name '*.sh' -print0 | xargs -0 -I {} shellcheck {}
-	find tests -type f -name '*.bats' -o -name '*.bash' -print0 | xargs -0 -I {} shellcheck {}
+	@find src utils -type f -name '*.sh' -print0 | xargs -0 -I {} shellcheck {}
+	@find tests -type f -name '*.bats' -o -name '*.bash' -print0 | xargs -0 -I {} shellcheck {}
 
 #
 # Packaging:

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -75,7 +75,7 @@ function stop_gpg_agent {
 function get_gpgtest_prefix {
   if [[ $GPG_VER_21 -eq 1  ]]; then
     # shellcheck disable=SC2086
-    echo "echo $(test_user_password \"$1\") | "
+    echo "echo \"$(test_user_password $1)\" | "
   else
     echo ""
   fi

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+!/usr/bin/env bash
 
 # This file is following a name convention defined in:
 # https://github.com/bats-core/bats-core
@@ -35,21 +35,21 @@ GPGTEST="$SECRETS_GPG_COMMAND --homedir=$TEST_GPG_HOMEDIR --no-permission-warnin
 # Personal data:
 
 # these two are 'normal' keys
-local TEST_DEFAULT_USER="user1@gitsecret.io"
-local TEST_SECOND_USER="user2@gitsecret.io"
+export TEST_DEFAULT_USER="user1@gitsecret.io"
+export TEST_SECOND_USER="user2@gitsecret.io"
 
 # TEST_NONAME_USER (user3) created with '--quick-key-generate' and has only an email, no username.
-local TEST_NONAME_USER="user3@gitsecret.io"
+export TEST_NONAME_USER="user3@gitsecret.io"
 
 # TEST_EXPIRED_USER (user4) has expired
-local TEST_EXPIRED_USER="user4@gitsecret.io"    # this key expires 2018-09-24
+export TEST_EXPIRED_USER="user4@gitsecret.io"    # this key expires 2018-09-24
 
-local TEST_ATTACKER_USER="attacker1@gitsecret.io"
+export TEST_ATTACKER_USER="attacker1@gitsecret.io"
 
 
-local TEST_DEFAULT_FILENAME="space file" # has spaces
-local TEST_SECOND_FILENAME="space file two" # has spaces
-local TEST_THIRD_FILENAME="space file three"  # has spaces
+export TEST_DEFAULT_FILENAME="space file" # has spaces
+export TEST_SECOND_FILENAME="space file two" # has spaces
+export TEST_THIRD_FILENAME="space file three"  # has spaces
 
 
 function test_user_password {

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -3,7 +3,9 @@
 # This file is following a name convention defined in:
 # https://github.com/bats-core/bats-core
 
+# shellcheck disable=SC1090
 source "$SECRET_PROJECT_ROOT/src/version.sh"
+# shellcheck disable=SC1090
 source "$SECRET_PROJECT_ROOT/src/_utils/_git_secret_tools.sh"
 
 # Constants:
@@ -62,7 +64,8 @@ function test_user_password {
 # GPG:
 
 function stop_gpg_agent {
-  local username=$(id -u -n)
+  local username
+  username=$(id -u -n)
   ps -wx -U "$username" | gawk \
     '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("kill -9 "$1) } }' \
     > /dev/null 2>&1
@@ -101,10 +104,10 @@ function install_fixture_key {
 
 function install_fixture_full_key {
   local private_key="$BATS_TMPDIR/private-${1}.key"
-  local gpgtest_prefix=$(get_gpgtest_prefix "$1")
+  local gpgtest_prefix
+  gpgtest_prefix=$(get_gpgtest_prefix "$1") 
   local gpgtest_import="$gpgtest_prefix $GPGTEST"
   local email
-  local fp
   local fingerprint
 
   email="$1"

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -35,21 +35,21 @@ GPGTEST="$SECRETS_GPG_COMMAND --homedir=$TEST_GPG_HOMEDIR --no-permission-warnin
 # Personal data:
 
 # these two are 'normal' keys
-export TEST_DEFAULT_USER="user1@gitsecret.io"
-export TEST_SECOND_USER="user2@gitsecret.io"
+local TEST_DEFAULT_USER="user1@gitsecret.io"
+local TEST_SECOND_USER="user2@gitsecret.io"
 
 # TEST_NONAME_USER (user3) created with '--quick-key-generate' and has only an email, no username.
-export TEST_NONAME_USER="user3@gitsecret.io"
+local TEST_NONAME_USER="user3@gitsecret.io"
 
 # TEST_EXPIRED_USER (user4) has expired
-export TEST_EXPIRED_USER="user4@gitsecret.io"    # this key expires 2018-09-24
+local TEST_EXPIRED_USER="user4@gitsecret.io"    # this key expires 2018-09-24
 
-export TEST_ATTACKER_USER="attacker1@gitsecret.io"
+local TEST_ATTACKER_USER="attacker1@gitsecret.io"
 
 
-export TEST_DEFAULT_FILENAME="space file" # has spaces
-export TEST_SECOND_FILENAME="space file two" # has spaces
-export TEST_THIRD_FILENAME="space file three"  # has spaces
+local TEST_DEFAULT_FILENAME="space file" # has spaces
+local TEST_SECOND_FILENAME="space file two" # has spaces
+local TEST_THIRD_FILENAME="space file three"  # has spaces
 
 
 function test_user_password {

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -1,4 +1,4 @@
-!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # This file is following a name convention defined in:
 # https://github.com/bats-core/bats-core

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -3,9 +3,7 @@
 # This file is following a name convention defined in:
 # https://github.com/bats-core/bats-core
 
-# shellcheck disable=1090
 source "$SECRET_PROJECT_ROOT/src/version.sh"
-# shellcheck disable=1090
 source "$SECRET_PROJECT_ROOT/src/_utils/_git_secret_tools.sh"
 
 # Constants:
@@ -13,6 +11,7 @@ FIXTURES_DIR="$BATS_TEST_DIRNAME/fixtures"
 
 TEST_GPG_HOMEDIR="$BATS_TMPDIR"
 
+# shellcheck disable=SC2016
 AWK_GPG_GET_FP='
 BEGIN { OFS=":"; FS=":"; }
 {
@@ -34,29 +33,27 @@ GPGTEST="$SECRETS_GPG_COMMAND --homedir=$TEST_GPG_HOMEDIR --no-permission-warnin
 # Personal data:
 
 # these two are 'normal' keys
-TEST_DEFAULT_USER="user1@gitsecret.io"
-TEST_SECOND_USER="user2@gitsecret.io"
+export TEST_DEFAULT_USER="user1@gitsecret.io"
+export TEST_SECOND_USER="user2@gitsecret.io"
 
 # TEST_NONAME_USER (user3) created with '--quick-key-generate' and has only an email, no username.
-TEST_NONAME_USER="user3@gitsecret.io"
+export TEST_NONAME_USER="user3@gitsecret.io"
 
 # TEST_EXPIRED_USER (user4) has expired
-TEST_EXPIRED_USER="user4@gitsecret.io"    # this key expires 2018-09-24
+export TEST_EXPIRED_USER="user4@gitsecret.io"    # this key expires 2018-09-24
 
-TEST_ATTACKER_USER="attacker1@gitsecret.io"
+export TEST_ATTACKER_USER="attacker1@gitsecret.io"
 
-#TEST_DEFAULT_FILENAME="file_one"  # no spaces
-#TEST_SECOND_FILENAME="file_two"  # no spaces
-#TEST_THIRD_FILENAME="file_three"  # no spaces
 
-TEST_DEFAULT_FILENAME="space file" # has spaces
-TEST_SECOND_FILENAME="space file two" # has spaces
-TEST_THIRD_FILENAME="space file three"  # has spaces
+export TEST_DEFAULT_FILENAME="space file" # has spaces
+export TEST_SECOND_FILENAME="space file two" # has spaces
+export TEST_THIRD_FILENAME="space file three"  # has spaces
 
 
 function test_user_password {
   # Password for 'user3@gitsecret.io' is 'user3pass'
   # As it was set on key creation. 
+  # shellcheck disable=SC2001
   echo "$1" | sed -e 's/@.*/pass/' 
 }
 
@@ -74,7 +71,8 @@ function stop_gpg_agent {
 
 function get_gpgtest_prefix {
   if [[ $GPG_VER_21 -eq 1  ]]; then
-    echo "echo \"$(test_user_password $1)\" | "
+    # shellcheck disable=SC2086
+    echo "echo $(test_user_password \"$1\") | "
   else
     echo ""
   fi
@@ -87,7 +85,7 @@ function get_gpg_fingerprint_by_email {
 
   fingerprint=$($GPGTEST --with-fingerprint \
                          --with-colon \
-                         --list-secret-key $email | gawk "$AWK_GPG_GET_FP")
+                         --list-secret-key "$email" | gawk "$AWK_GPG_GET_FP")
   echo "$fingerprint"
 }
 
@@ -95,7 +93,7 @@ function get_gpg_fingerprint_by_email {
 function install_fixture_key {
   local public_key="$BATS_TMPDIR/public-${1}.key"
 
-  \cp "$FIXTURES_DIR/gpg/${1}/public.key" "$public_key"
+  cp "$FIXTURES_DIR/gpg/${1}/public.key" "$public_key"
   $GPGTEST --import "$public_key" > /dev/null 2>&1
   rm -f "$public_key"
 }
@@ -103,7 +101,7 @@ function install_fixture_key {
 
 function install_fixture_full_key {
   local private_key="$BATS_TMPDIR/private-${1}.key"
-  local gpgtest_prefix="$(get_gpgtest_prefix $1)"
+  local gpgtest_prefix=$(get_gpgtest_prefix "$1")
   local gpgtest_import="$gpgtest_prefix $GPGTEST"
   local email
   local fp
@@ -111,13 +109,13 @@ function install_fixture_full_key {
 
   email="$1"
 
-  \cp "$FIXTURES_DIR/gpg/${1}/private.key" "$private_key"
+  cp "$FIXTURES_DIR/gpg/${1}/private.key" "$private_key"
 
   bash -c "$gpgtest_import --allow-secret-key-import \
     --import \"$private_key\"" > /dev/null 2>&1
 
   # since 0.1.2 fingerprint is returned:
-  fingerprint=$(get_gpg_fingerprint_by_email $email)
+  fingerprint=$(get_gpg_fingerprint_by_email "$email")
 
   install_fixture_key "$1"
 


### PR DESCRIPTION
Initial cross-platform lint tests on tests/. For #368 "lint tests"