### PR TITLE
Revert "use pgrep & kill $pid, not ps+gawk+regex+system+kill"

### DIFF
--- a/.ci/before_script.sh
+++ b/.ci/before_script.sh
@@ -24,7 +24,7 @@ if [[ "$GITSECRET_DIST" == "brew" ]]; then
   if [[ -f "/usr/local/bin/gpg1" ]]; then
     ln -s /usr/local/bin/gpg1 /usr/local/bin/gpg
   fi
-  brew install gawk shellcheck
+  brew install gawk
 fi
 
 # Linux:

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -16,7 +16,6 @@ function run_kitchen_tests {
 if [[ "$GITSECRET_DIST" == "brew" ]]; then
   # Only running `make test` on standard (non-docker) build,
   # since it is called inside the docker container anyway.
-  make lint
   make test
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ dist: xenial
 matrix:
   fast_finish: true
   include:
-    - os: osx
-      env: GITSECRET_DIST="brew"
-      sudo: required
-      language: ruby
-      rvm: 2.6
     - os: linux
       env: KITCHEN_REGEXP="gnupg1-alpine-latest"
       services: docker
@@ -85,6 +80,11 @@ matrix:
     - os: linux
       env: KITCHEN_REGEXP="gnupg-git-ubuntu-rolling"
       services: docker
+      sudo: required
+      language: ruby
+      rvm: 2.6
+    - os: osx
+      env: GITSECRET_DIST="brew"
       sudo: required
       language: ruby
       rvm: 2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,11 @@
 
 ## Misc
 
-- Use Shellcheck on tests/ files (#368)
-- Run Shellcheck on osx travis tests (#403)
+- Use Shellcheck on tests/ files, changes for Shellcheck in tests/ (#368)
 - Document SECRETS_VERBOSE and improve env var docs (#396)
 - Update CHANGELOG.md to mention fix for #281 in v0.2.5 (#311)
 - Add text explaining git-secret Style Guide and Development Philosophy
 - Upgrade bats-core to v1.1.0, import bats-core into vendor/bats-core (#377)
-- Use pgrep and kill to stop test gpg-agent subprocess (#376)
 
 ## Version 0.2.5
 

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -66,17 +66,9 @@ function test_user_password {
 function stop_gpg_agent {
   local username
   username=$(id -u -n)
-  local pid
-  pid=$(pgrep -U "$username" -f "gpg-agent --homedir.*$TEST_GPG_HOMEDIR")
-  if [[ -n "$pid" ]]; then
-
-    # shellcheck disable=SC2001
-    #echo "$pid" | sed "s/^/# '$BATS_TEST_DESCRIPTION' killing pid(s): /" >&3
-
-    # we want $pid to be whitespace split below, so don't quote
-    # shellcheck disable=SC2086
-    kill $pid
-  fi
+  ps -wx -U "$username" | gawk \
+    '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("kill "$1) } }' \
+    > /dev/null 2>&1
 }
 
 


### PR DESCRIPTION
Reverts sobolevn/git-secret#400  for now

We can't find `pgrep` on our windows builds, and this needs more testing.