### PR TITLE
Re enable travis windows

### DIFF
--- a/.ci/before_script.sh
+++ b/.ci/before_script.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+echo "In .ci/before_script.sh"
+
 # Linux helper functions:
 function update_linux() {
   sudo apt-get update -qq
@@ -29,6 +31,7 @@ fi
 
 # Windows
 if [[ "$GITSECRET_DIST" == "windows" ]]; then
+  echo "running 'choco install make shellcheck -y'"
   choco install make shellcheck -y
 fi
 

--- a/.ci/before_script.sh
+++ b/.ci/before_script.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "In .ci/before_script.sh"
+echo "Debug: In .ci/before_script.sh"
 
 # Linux helper functions:
 function update_linux() {
@@ -31,7 +31,7 @@ fi
 
 # Windows
 if [[ "$GITSECRET_DIST" == "windows" ]]; then
-  echo "running 'choco install make shellcheck -y'"
+  echo "Debug: Running: 'choco install make shellcheck -y'"
   choco install make shellcheck -y
 fi
 
@@ -40,3 +40,5 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ -n "$KITCHEN_REGEXP" ]]; then
   update_linux
   install_ansible
 fi
+
+echo "Debug: Exiting .ci/before_script.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ dist: xenial
 matrix:
   fast_finish: true
   include:
-    #- os: windows
-    #  env: GITSECRET_DIST="windows"
-    #  sudo: required
-    #  language: sh
+    - os: windows
+      env: GITSECRET_DIST="windows"
+      sudo: required
+      language: sh
     - os: osx
       env: GITSECRET_DIST="brew"
       sudo: required


### PR DESCRIPTION
For #409  , in which all the travis tests pass _until_ we merge into master. (It could be an issue in the currently experimental travis `windows` environment)

This PR is expected to pass, and if #409 persists, after merging we'll see an error in master with a little debug information. Then I'll revert and rethink.

If it passes tests in master after merging, I'll remove the debug info and we've fixed the windows tests.

