### PR TITLE
break loop when email found in keyring

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -596,6 +596,7 @@ function _assert_keychain_contains_emails {
     for uid in $gpg_uids; do
         if [[ "$uid" == "$email" ]]; then
             email_ok=1
+            break
         fi
     done
     if [[ $email_ok -eq 0 ]]; then


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .ronn file(s) in man/man*/ to document your changes if appropriate 
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Improves efficiency. 

Does this close any currently open issues?
------------------------------------------
N/A

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
The unit tests don't have a lot of public keys in the test keyring. Adding this improvement only reduces the number of comparisons from 198 to 176. With real-world usage, we can expect the keyrings to contain a lot of email address. So this change will prevent a lot of redundant string comparisons. 