### PR TITLE
remove dead code for keys/mapping.cfg

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -8,7 +8,6 @@ _SECRETS_DIR_KEYS="${_SECRETS_DIR}/keys"
 _SECRETS_DIR_PATHS="${_SECRETS_DIR}/paths"
 
 # Files:
-_SECRETS_DIR_KEYS_MAPPING="${_SECRETS_DIR_KEYS}/mapping.cfg"
 _SECRETS_DIR_KEYS_TRUSTDB="${_SECRETS_DIR_KEYS}/trustdb.gpg"
 
 _SECRETS_DIR_PATHS_MAPPING="${_SECRETS_DIR_PATHS}/mapping.cfg"
@@ -392,11 +391,6 @@ function _get_secrets_dir_keys {
 
 function _get_secrets_dir_path {
   _append_root_path "${_SECRETS_DIR_PATHS}"
-}
-
-
-function _get_secrets_dir_keys_mapping {
-  _append_root_path "${_SECRETS_DIR_KEYS_MAPPING}"
 }
 
 

--- a/src/commands/git_secret_init.sh
+++ b/src/commands/git_secret_init.sh
@@ -71,7 +71,7 @@ function init {
   # Create internal files:
 
   mkdir "$git_secret_dir" "$(_get_secrets_dir_keys)" "$(_get_secrets_dir_path)"
-  touch "$(_get_secrets_dir_keys_mapping)" "$(_get_secrets_dir_paths_mapping)"
+  touch "$(_get_secrets_dir_paths_mapping)"
 
   _message "init created: '$git_secret_dir/'"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .ronn file(s) in man/man*/ to document your changes if appropriate 
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Removes dead code. 

Does this close any currently open issues?
------------------------------------------
N/A

Any relevant logs, error output, etc?
-------------------------------------
N/A

Any other comments?
-------------------
I was trying to figure out what keys/mapping.cfg does then realise that i could not find any code that uses it. Deleting it and any references to it doesn't break any test. I feel slightly uncomfortable in deleting the code since I don't yet consider myself familiar with the codebase. I am also unsure whether test coverage is sufficient to really confirm that this is indeed dead code. Was this something that was used in the past but was made redundant by a refactor? 