### PR TITLE
git secret hide docs warns about `-F` but not `-m` behaviour #467

### DIFF
--- a/man/man1/git-secret-hide.1.ronn
+++ b/man/man1/git-secret-hide.1.ronn
@@ -26,8 +26,10 @@ it's possible to make it so some files can no longer be decrypted by users who s
 (and would appear) able to decrypt them, and vice-versa.
 
 If you know what you are doing and wish to encrypt or re-encrypt only a subset of the files 
-even after reading the above paragraphs, you can use the -F option to force `git secret hide` 
-to skip any hidden files where the unencrypted versions aren't present. 
+even after reading the above paragraphs, you can use the -F or -m option to only encrypted 
+a subset of files. The -F option forces `git secret hide` to either skip any hidden files 
+where the unencrypted versions aren't present. The -m option skips any hidden files that have 
+not be modified since the last time they were encrypted. 
 
 Also, it is possible to modify the names of the encrypted files by setting `SECRETS_EXTENSION` variable.
 

--- a/man/man1/git-secret-hide.1.ronn
+++ b/man/man1/git-secret-hide.1.ronn
@@ -27,7 +27,7 @@ it's possible to make it so some files can no longer be decrypted by users who s
 
 If you know what you are doing and wish to encrypt or re-encrypt only a subset of the files 
 even after reading the above paragraphs, you can use the -F or -m option to only encrypted 
-a subset of files. The -F option forces `git secret hide` to either skip any hidden files 
+a subset of files. The -F option forces `git secret hide` to skip any hidden files 
 where the unencrypted versions aren't present. The -m option skips any hidden files that have 
 not be modified since the last time they were encrypted. 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .ronn file(s) in man/man*/ to document your changes if appropriate 
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------

Documentation improvement. 

Does this close any currently open issues?
------------------------------------------

#467 git secret hide docs warn about `-F` but not `-m` behaviour

