### PR TITLE
fix for git secret hide -m doesn't work on first use #466

### DIFF
--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -65,7 +65,7 @@ function _get_file_hash {
   echo "$file_hash"
 }
 
-function _optional_fsdb_update_hash {
+function _fsdb_update_hash {
   local key="$1"
   local hash="$2"
   local fsdb          # path_mappings
@@ -80,7 +80,7 @@ function hide {
   local clean=0
   local preserve=0
   local delete=0
-  local fsdb_update_hash=0 # add checksum hashes to fsdb
+  local update_only_modified=0
   local force_continue=0
 
   OPTIND=1
@@ -95,7 +95,7 @@ function hide {
 
       d) delete=1;;
 
-      m) fsdb_update_hash=1;;
+      m) update_only_modified=1;;
 
       v) _SECRETS_VERBOSE=1;;
 
@@ -160,7 +160,7 @@ function hide {
       file_hash=$(_get_file_hash "$input_path")
   
       # encrypt file only if required
-      if [[ "$fsdb_file_hash" != "$file_hash" ]]; then
+      if [[ "$update_only_modified" -eq 0 ]] || [[ "$fsdb_file_hash" != "$file_hash" ]]; then
 
         local args=( --homedir "$secrets_dir_keys" "--no-permission-warning" --use-agent --yes "--trust-model=always" --encrypt )
 
@@ -193,12 +193,10 @@ function hide {
           fi
         fi
   
-        # If -m option was provided, it will update unencrypted file hash
+        # Update file hash for future use of -m
         local key="$filename"
         local hash="$file_hash"
-        # Update file hash if required in fsdb
-        [[ "$fsdb_update_hash" -gt 0 ]] && \
-          _optional_fsdb_update_hash "$key" "$hash"
+        _fsdb_update_hash "$key" "$hash"
       fi
     fi
   done

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -54,8 +54,7 @@ function teardown {
 
   # Command must execute normally. 
   [ "$status" -eq 0 ]
-
-  echo "$output" | grep "git-secret: done. 1 of 1 files are hidden."
+  [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 }
 
 @test "run 'hide' with '-P'" {
@@ -173,7 +172,7 @@ function teardown {
   # Command must execute normally:
   [ "$status" -eq 0 ]
   # git secret hide -m: uses temp file so cleaning should take place, but we only show tmp file cleanup in VERBOSE mode
-  [ "${lines[0]}" = "git-secret: done. 1 of 1 files are hidden." ]
+  [[ "${lines[0]}" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # back path mappings
   cp "${path_mappings}" "${path_mappings}.bak"
@@ -184,7 +183,7 @@ function teardown {
   [[ "${#lines[@]}" -eq 1 ]]
   
   # output says 0 of 1 files are hidden because checksum didn't change and we didn't need to hide it again.
-  [ "$output" = "git-secret: done. 0 of 1 files are hidden." ]
+  [[ "$output" == *"git-secret: done. 0 of 1 files are hidden."* ]]
   # no changes should occur to path_mappings files
   cmp -s "${path_mappings}" "${path_mappings}.bak"
 
@@ -204,7 +203,7 @@ function teardown {
   # Command must execute normally:
   [ "$status" -eq 0 ]
   # git secret hide -m: uses temp file so cleaning should take place, but we only show tmp file cleanup in VERBOSE mode
-  [ "${lines[0]}" = "git-secret: done. 1 of 1 files are hidden." ]
+  [[ "${lines[0]}" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # back path mappings
   cp "${path_mappings}" "${path_mappings}.bak"
@@ -215,7 +214,7 @@ function teardown {
   [[ "${#lines[@]}" -eq 1 ]]
   
   # output says 0 of 1 files are hidden because checksum didn't change and we didn't need to hide it again.
-  [ "$output" = "git-secret: done. 0 of 1 files are hidden." ]
+  [[ "$output" == *"git-secret: done. 0 of 1 files are hidden."* ]]
   # no changes should occur to path_mappings files
   cmp -s "${path_mappings}" "${path_mappings}.bak"
 

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -32,7 +32,7 @@ function teardown {
 
   # Command must execute normally:
   [ "$status" -eq 0 ]
-  [ "$output" = "git-secret: done. 1 of 1 files are hidden." ]
+  [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # New files should be created:
   local encrypted_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
@@ -68,7 +68,7 @@ function teardown {
 
   # Command must execute normally:
   [ "$status" -eq 0 ]
-  [ "$output" = "git-secret: done. 1 of 1 files are hidden." ]
+  [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # New files should be created:
   local encrypted_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
@@ -141,7 +141,7 @@ function teardown {
   run git secret hide
   #echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
   [ "$status" -eq 0 ]
-  [ "$output" = "git-secret: done. 2 of 2 files are hidden." ]
+  [[ "$output" == *"git-secret: done. 2 of 2 files are hidden."* ]]
 
   # Cleaning up:
   rm "$second_file"
@@ -295,5 +295,5 @@ function teardown {
 
   run git secret hide
   [ "$status" -eq 0 ]
-  [ "$output" = "git-secret: done. 1 of 1 files are hidden." ]
+  [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 }

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -50,11 +50,12 @@ function teardown {
 }
 
 @test "run 'hide' normally with SECRETS_VERBOSE=1" {
-  SECRETS_VERBOSE=1 run git secret hide
+  SECRETS_VERBOSE=1 run git secret hide 
 
   # Command must execute normally. 
   [ "$status" -eq 0 ]
-  [[ "$output" == "git-secret: done. 1 of 1 files are hidden." ]]
+
+  echo "$output" | grep "git-secret: done. 1 of 1 files are hidden."
 }
 
 @test "run 'hide' with '-P'" {
@@ -166,6 +167,37 @@ function teardown {
   local path_mappings
   path_mappings=$(_get_secrets_dir_paths_mapping)
   run git secret hide -m
+
+  #echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
+
+  # Command must execute normally:
+  [ "$status" -eq 0 ]
+  # git secret hide -m: uses temp file so cleaning should take place, but we only show tmp file cleanup in VERBOSE mode
+  [ "${lines[0]}" = "git-secret: done. 1 of 1 files are hidden." ]
+
+  # back path mappings
+  cp "${path_mappings}" "${path_mappings}.bak"
+  # run hide again
+  run git secret hide -m
+  # compare
+  [ "$status" -eq 0 ]
+  [[ "${#lines[@]}" -eq 1 ]]
+  
+  # output says 0 of 1 files are hidden because checksum didn't change and we didn't need to hide it again.
+  [ "$output" = "git-secret: done. 0 of 1 files are hidden." ]
+  # no changes should occur to path_mappings files
+  cmp -s "${path_mappings}" "${path_mappings}.bak"
+
+  # New files should be created:
+  local encrypted_file=$(_get_encrypted_filename "$FILE_TO_HIDE")
+  [ -f "$encrypted_file" ]
+}
+
+
+@test "run 'hide' without then with '-m'" {
+  local path_mappings
+  path_mappings=$(_get_secrets_dir_paths_mapping)
+  run git secret hide
 
   #echo "$output" | sed "s/^/# '$BATS_TEST_DESCRIPTION' output: /" >&3
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .ronn file(s) in man/man*/ to document your changes if appropriate 
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------

Ensures that hidden files always have hashes in fsdb. 

Does this close any currently open issues?
------------------------------------------

#466 git secret hide -m doesn't work on first use

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------

N/A