### PR TITLE
fix tests on busybox

### DIFF
--- a/.Dockerfiles/alpine/latest/Dockerfile
+++ b/.Dockerfiles/alpine/latest/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:latest
 
+# don't install coreutils, so we get busybox versions of stat and mktemp. See #475
 RUN apk add --no-cache --update \
 	bash \
 	build-base \
-	coreutils \
 	curl \
 	findutils \
 	gcc \

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       #language: ruby
       #rvm: 2.6
     - os: linux
-      env: KITCHEN_REGEXP="gnupg1-alpine-latest"
+      env: KITCHEN_REGEXP="gnupg1-alpine-latest" SECRETS_TEST_VERBOSE=1
       services: docker
       sudo: required
       language: ruby
@@ -51,7 +51,7 @@ matrix:
       language: ruby
       rvm: 2.6
     - os: linux
-      env: KITCHEN_REGEXP="gnupg2-alpine-latest"
+      env: KITCHEN_REGEXP="gnupg2-alpine-latest" SECRETS_TEST_VERBOSE=1
       services: docker
       sudo: required
       language: ruby

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -153,6 +153,21 @@ function _clean_windows_path {
   echo "$1" | sed 's#^\([a-zA-Z]\):/#/\1/#'
 }
 
+function _exe_is_busybox {
+  local exe
+  exe=$1
+
+  # we assume stat is from busybox if it's a symlink
+  local is_busybox=0
+  local stat_path
+  stat_path=$(command -v "$exe")
+  if [ -L "$stat_path" ]; then
+    is_busybox=1
+  fi
+  echo"$is_busybox"
+
+}
+
 function _set_config {
   # This function creates a line in the config, or alters it.
 

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -23,8 +23,8 @@ function __temp_file_linux {
   #         relative to a directory: $TMPDIR, if set; else the directory 
   #         specified via -p; else /tmp [deprecated]
 
-  filename=$(mktemp -p "${TMPDIR}" _git_secret.XXXXX ) 
-  # makes a filename like /$TMPDIR/_git_secret.ONIHo
+  filename=$(mktemp -p "${TMPDIR}" _git_secret.XXXXXX ) 
+  # makes a filename like /$TMPDIR/_git_secret.ONIHoR
   echo "$filename"
 }
 

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -36,7 +36,7 @@ function __get_octal_perms_linux {
   local filename
   filename=$1
   local perms
-  perms=$(stat --format '%a' "$filename")
+  perms=$(stat --format '%a' "$filename" || stat -f '%a' "$filename")
   # a string like '0644'
   echo "$perms"
 }

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -44,10 +44,10 @@ function __get_octal_perms_linux {
     stat_from_busybox=1
   fi
 
-  local perms   # a string like '0644'
+  local perms   # a string like '644'
   if [ $stat_from_busybox -eq 1 ]; then
     # special case for busybox, which doesn't understand --format
-    perms=$(stat -f '%a' "$filename")
+    perms=$(stat -c '%a' "$filename")	
   else
     perms=$(stat --format '%a' "$filename")
   fi

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -35,10 +35,22 @@ function __sha256_linux {
 function __get_octal_perms_linux {
   local filename
   filename=$1
-  local perms
-  # special case for busybox, which doesn't understand --format
-  perms=$(stat --format '%a' "$filename" || stat -f '%a' "$filename")
-  # a string like '0644'
+
+  # we assume stat is from busybox if it's a symlink
+  local stat_from_busybox=0
+  local stat_path
+  stat_path=$(command -v stat)
+  if [ -L "$stat_path" ]; then
+    stat_from_busybox=1
+  fi
+
+  local perms   # a string like '0644'
+  if [ $stat_from_busybox -eq 1 ]; then
+    # special case for busybox, which doesn't understand --format
+    perms=$(stat -f '%a' "$filename")
+  else
+    perms=$(stat --format '%a' "$filename")
+  fi
   echo "$perms"
 }
 

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -36,9 +36,10 @@ function __get_octal_perms_linux {
   local filename
   filename=$1
 
-  local stat_is_busybox=_exe_is_busybox "stat"
+  local stat_is_busybox
+  stat_is_busybox=_exe_is_busybox "stat"
   local perms   # a string like '644'
-  if [ $stat_from_busybox -eq 1 ]; then
+  if [ "$stat_is_busybox" -eq 1 ]; then
     # special case for busybox, which doesn't understand --format
     perms=$(stat -c '%a' "$filename")	
   else

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -36,6 +36,7 @@ function __get_octal_perms_linux {
   local filename
   filename=$1
   local perms
+  # special case for busybox, which doesn't understand --format
   perms=$(stat --format '%a' "$filename" || stat -f '%a' "$filename")
   # a string like '0644'
   echo "$perms"

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -36,14 +36,7 @@ function __get_octal_perms_linux {
   local filename
   filename=$1
 
-  # we assume stat is from busybox if it's a symlink
-  local stat_from_busybox=0
-  local stat_path
-  stat_path=$(command -v stat)
-  if [ -L "$stat_path" ]; then
-    stat_from_busybox=1
-  fi
-
+  local stat_is_busybox=_exe_is_busybox "stat"
   local perms   # a string like '644'
   if [ $stat_from_busybox -eq 1 ]; then
     # special case for busybox, which doesn't understand --format

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -76,7 +76,7 @@ function stop_gpg_agent {
   else
     local ps_is_busybox
     ps_is_busybox=exe_is_busybox $(command -v ps)
-    if [ $ps_is_busybox -eq "1" ]; then
+    if [[ $ps_is_busybox -eq "1" ]]; then
       echo "# git-secret: tests: not stoping gpg-agent on busybox" >&3
     else
       ps -wx -U "$username" | gawk \

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -74,8 +74,10 @@ function stop_gpg_agent {
     ps -l -u "$username" | gawk \
       '/gpg-agent/ { if ( $0 !~ "awk" ) { system("kill "$1) } }' >> "$TEST_GPG_OUTPUT_FILE" 2>&1
   else
+    local ps_exe
+    ps_exe=$(command -v ps)
     local ps_is_busybox
-    ps_is_busybox=exe_is_busybox $(command -v ps)
+    ps_is_busybox=exe_is_busybox "$ps_exe"
     if [[ $ps_is_busybox -eq "1" ]]; then
       echo "# git-secret: tests: not stoping gpg-agent on busybox" >&3
     else

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -75,7 +75,7 @@ function stop_gpg_agent {
       '/gpg-agent/ { if ( $0 !~ "awk" ) { system("kill "$1) } }' >> "$TEST_GPG_OUTPUT_FILE" 2>&1
   else
     local ps_is_busybox
-    ps_is_busybox=exe_is_busybox "ps"
+    ps_is_busybox=_exe_is_busybox "ps"
     if [[ $ps_is_busybox -eq "1" ]]; then
       echo "# git-secret: tests: not stopping gpg-agent on busybox" >&3
     else

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -74,8 +74,14 @@ function stop_gpg_agent {
     ps -l -u "$username" | gawk \
       '/gpg-agent/ { if ( $0 !~ "awk" ) { system("kill "$1) } }' >> "$TEST_GPG_OUTPUT_FILE" 2>&1
   else
-    ps -wx -U "$username" | gawk \
-      '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("kill "$1) } }' >> "$TEST_GPG_OUTPUT_FILE" 2>&1 
+    local ps_is_busybox
+    ps_is_busybox=exe_is_busybox $(command -v ps)
+    if [ $ps_is_busybox -eq "1" ]; then
+      echo "# git-secret: tests: not stoping gpg-agent on busybox" >&3
+    else
+      ps -wx -U "$username" | gawk \
+        '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("kill "$1) } }' >> "$TEST_GPG_OUTPUT_FILE" 2>&1 
+    fi
   fi
 }
 

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -74,12 +74,10 @@ function stop_gpg_agent {
     ps -l -u "$username" | gawk \
       '/gpg-agent/ { if ( $0 !~ "awk" ) { system("kill "$1) } }' >> "$TEST_GPG_OUTPUT_FILE" 2>&1
   else
-    local ps_exe
-    ps_exe=$(command -v ps)
     local ps_is_busybox
-    ps_is_busybox=exe_is_busybox "$ps_exe"
+    ps_is_busybox=exe_is_busybox "ps"
     if [[ $ps_is_busybox -eq "1" ]]; then
-      echo "# git-secret: tests: not stoping gpg-agent on busybox" >&3
+      echo "# git-secret: tests: not stopping gpg-agent on busybox" >&3
     else
       ps -wx -U "$username" | gawk \
         '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("kill "$1) } }' >> "$TEST_GPG_OUTPUT_FILE" 2>&1 


### PR DESCRIPTION
For #478. This PR tries to fix tests when `ps` and `stat` come from busybox 
(Such as with an Alpine system without `coreutils`: see  .Dockerfiles/alpine/latest/Dockerfile )

Also includes fix for #475 