### PR TITLE
fix for mktemp on busybox.

### DIFF
--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -23,7 +23,7 @@ function __temp_file_linux {
   #         relative to a directory: $TMPDIR, if set; else the directory 
   #         specified via -p; else /tmp [deprecated]
 
-  filename=$(mktemp -p "${TMPDIR}" _git_secret.XXXXX ) 
+  filename=$(mktemp -p "${TMPDIR}" _git_secret.XXXXXX ) 
   # makes a filename like /$TMPDIR/_git_secret.ONIHo
   echo "$filename"
 }


### PR DESCRIPTION
Closes #475 so that 'git secret init' works on busybox systems (such as Alpine Linux without 'coreutils' installed)