### PR TITLE
fix for busybox mktemp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bugfixes
 
+- Fix git-secret init when used on busybox (#475)
 - Update git-secret.io, fix utils/gh-branch.sh to use 'git all --add' (#344)
 - Fix link to homebrew's git-secret in README.md (#310)
 - Remove diagnostic output from test results (#324)

--- a/src/_utils/_git_secret_tools_linux.sh
+++ b/src/_utils/_git_secret_tools_linux.sh
@@ -23,7 +23,7 @@ function __temp_file_linux {
   #         relative to a directory: $TMPDIR, if set; else the directory 
   #         specified via -p; else /tmp [deprecated]
 
-  filename=$(mktemp -p "${TMPDIR}" _git_secret.XXXXX ) 
+  filename=$(mktemp -p "${TMPDIR}" _git_secret.XXXXXX ) 
   # makes a filename like /$TMPDIR/_git_secret.ONIHo
   echo "$filename"
 }


### PR DESCRIPTION
Closes #475, so that 'git secret init' works on busybox systems.

Can be tested on Alpine Linux without 'coreutils' installed.

See also PR #477, which tries to fix all tests on busybox.