### PR TITLE
when we say gnupg1 don't use gnupg2

### DIFF
--- a/.ci/integration/gnupg1/default.yml
+++ b/.ci/integration/gnupg1/default.yml
@@ -20,9 +20,9 @@
       when:
         - ansible_distribution == item.distribution
       with_items:
-        - name: gnupg
+        - name: gnupg1
           distribution: Alpine
-        - name: gnupg
+        - name: gnupg1
           distribution: Fedora
         - name: gnupg1
           distribution: Debian


### PR DESCRIPTION
Use gnupg version 1 in Alpine and Fedora gnupg1 tests