### PR TITLE
Fix hangs when interrupting tests on OSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@
 - Use OSX's mktemp on OSX, even if there's another version in PATH. (#485)
 - Make rsync a build requirement on debian (#500)
 - When tests specify gnupg1, use gnupg1, not gnupg2 (#241)
-- Close file descriptor 3 when running 'long' subprocesses
 
 ## Misc
 
 - Add note about secrets and old keys (#499)
 - Transition build process from python 2 to python 3 (#487)
 - Upgrade build process from ansible 2.5 to ansible 2.8
-- Fix in build process when installing gnupg2 source deps on Ubuntu
+- Fix build process when installing gnupg2 source deps on Ubuntu
+- Close file descriptor 3 when running gnupg subprocesses (#521)
 - Small optimization in 'hide'
 - Improve code comments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Use OSX's mktemp on OSX, even if there's another version in PATH. (#485)
 - Make rsync a build requirement on debian (#500)
 - When tests specify gnupg1, use gnupg1, not gnupg2 (#241)
+- Close file descriptor 3 when running 'long' subprocesses
 
 ## Misc
 

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -171,10 +171,11 @@ function hide {
         set +e   # disable 'set -e' so we can capture exit_code
 
         if [[ -n "$_SECRETS_VERBOSE" ]]; then
+      	  # see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-
           # on at least some platforms, this doesn't output anything unless there's a warning or error
-          $SECRETS_GPG_COMMAND "${args[@]}"
+          $SECRETS_GPG_COMMAND "${args[@]}" 3>&-
         else 
-          $SECRETS_GPG_COMMAND "${args[@]}" > /dev/null 2>&1
+          $SECRETS_GPG_COMMAND "${args[@]}" > /dev/null 2>&1 3>&-
         fi
         local exit_code=$?
 

--- a/src/commands/git_secret_killperson.sh
+++ b/src/commands/git_secret_killperson.sh
@@ -31,7 +31,8 @@ function killperson {
   _assert_keychain_contains_emails "$secrets_dir_keys" "${emails[@]}"
 
   for email in "${emails[@]}"; do
-    $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --batch --yes --delete-key "$email"
+    # see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-
+    $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --batch --yes --delete-key "$email" 3>&-
     local exit_code=$?
     if [[ "$exit_code" -ne 0 ]]; then
       _abort "problem deleting key for '$email' with gpg: exit code $exit_code"

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -10,7 +10,8 @@ END { print cnt }
 function get_gpg_key_count {
   local secrets_dir_keys
   secrets_dir_keys=$(_get_secrets_dir_keys)
-  $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --list-public-keys --with-colon | gawk "$AWK_GPG_KEY_CNT"
+  # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs
+  $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --list-public-keys --with-colon | gawk "$AWK_GPG_KEY_CNT" 3>&-
   local exit_code=$?
   if [[ "$exit_code" -ne 0 ]]; then
     _abort "problem counting keys with gpg: exit code $exit_code"
@@ -75,14 +76,15 @@ function tell {
     # shellcheck disable=2154
     local keyfile="$temporary_filename"
 
+    # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs
     local exit_code
     if [[ -z "$homedir" ]]; then
-      $SECRETS_GPG_COMMAND --export -a "$email" > "$keyfile"
+      $SECRETS_GPG_COMMAND --export -a "$email" > "$keyfile" 3>&-
       exit_code=$?
     else
       # It means that homedir is set as an extra argument via `-d`:
       $SECRETS_GPG_COMMAND --no-permission-warning --homedir="$homedir" \
-        --export -a "$email" > "$keyfile"
+        --export -a "$email" > "$keyfile" 3>&-
       exit_code=$?
     fi
     if [[ "$exit_code" -ne 0 ]]; then
@@ -99,9 +101,9 @@ function tell {
 
     local args=( --homedir "$secrets_dir_keys" --no-permission-warning --import "$keyfile" )
     if [[ -z "$_SECRETS_VERBOSE" ]]; then
-      $SECRETS_GPG_COMMAND "${args[@]}" > /dev/null 2>&1
+      $SECRETS_GPG_COMMAND "${args[@]}" > /dev/null 2>&1 3>&-
     else
-      $SECRETS_GPG_COMMAND "${args[@]}"
+      $SECRETS_GPG_COMMAND "${args[@]}" 3>&-
     fi
     exit_code=$?
 


### PR DESCRIPTION
Closes #521 by making sure fd 3 is closed when we run gnupg subprocesses.