### PR TITLE
Issue 536 backward compat docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Close file descriptor 3 when running gnupg subprocesses (#521)
 - Small optimization in 'hide'
 - Improve code comments
-- Update docs to note that git-secret repos modified by git-secret 0.2.3 or 
+- Update docs to note that git-secret repos modified by git-secret 0.2.3 and
   later are not backward compatible with pre-0.2.3 versions of git-secret.
 
 ## Version 0.2.6
@@ -136,7 +136,8 @@
 
 - Added `-m` option to `hide` command, files will only be hidden when modifications are detected (#92)
 - Changed how path mappings file works: colon delimited FSDB in `.gitsecret/paths/mapping.cfg', so git-secret
-  can store checksums of hidden files. Note this breaks backward compatibility with pre-0.2.3 versions.  (#92) 
+  can store checksums of hidden files. Note this means git-secret repos modified by git-secret 0.2.3 
+  or later are not backward compatible with pre-0.2.3 versions of git-secret. (#92)
 - `git secret init` now adds `random_seed` to `.gitignore` (#93)
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Close file descriptor 3 when running gnupg subprocesses (#521)
 - Small optimization in 'hide'
 - Improve code comments
+- Update docs to note that git-secret repos modified by git-secret 0.2.3 or 
+  later are not backward compatible with pre-0.2.3 versions of git-secret.
 
 ## Version 0.2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@
 
 - Added `-m` option to `hide` command, files will only be hidden when modifications are detected (#92)
 - Changed how path mappings file works: colon delimited FSDB in `.gitsecret/paths/mapping.cfg', so git-secret
-  can store checksums of hidden files. Note that that breaks backward compatibility with pre-0.2.3 versions.  (#92) 
+  can store checksums of hidden files. Note this breaks backward compatibility with pre-0.2.3 versions.  (#92) 
 - `git secret init` now adds `random_seed` to `.gitignore` (#93)
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,8 @@
 ### Features
 
 - Added `-m` option to `hide` command, files will only be hidden when modifications are detected (#92)
-- Changed how path mappings file works: colon delimited FSDB (#92)
+- Changed how path mappings file works: colon delimited FSDB in `.gitsecret/paths/mapping.cfg', so git-secret
+  can store checksums of hidden files. Note that that breaks backward compatibility with pre-0.2.3 versions.  (#92) 
 - `git secret init` now adds `random_seed` to `.gitignore` (#93)
 
 ### Bugfixes
@@ -143,8 +144,6 @@
 
 ### Misc
 
-- Backward Compatibilty: git-secret now stores checksums of hidden files mapping.cfg, so `.gitsecret/paths/mapping.cfg` 
-  files generated or updated by git-secret after and including 0.2.3 will not be understood by older versions of git-secret.
 - Now users can run local CI tests using test-kitchen (#6)
 - Migrated travis ci tests to test-kitchen for Linux platforms.
 - Added more `gpg` version to test matrix (#99)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,8 @@
 
 ### Misc
 
+- Backward Compatibilty: git-secret now stores checksums of hidden files mapping.cfg, so `.gitsecret/paths/mapping.cfg` 
+  files generated or updated by git-secret after and including 0.2.3 will not be understood by older versions of git-secret.
 - Now users can run local CI tests using test-kitchen (#6)
 - Migrated travis ci tests to test-kitchen for Linux platforms.
 - Added more `gpg` version to test matrix (#99)


### PR DESCRIPTION
This PR is for #536, which notes that if you cannot use a gitsecret repo from 0.2.3 or later with an older version of git-secret. (That is, it is not backward compatible). 

You can always use repos from and _older_ version of git secret on a _newer_ version.