### PR TITLE
Update bats core to beta version, for streamlined testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## {{Next Version}}
+
+### Misc
+
+- Update bats-core to beta version e582ef5, for faster testing (#540)
+
 ## Version 0.3.2
 
 ### Bugfixes

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,6 +1,6 @@
 README for git-secret/vendor directory
 
-We import bats-core v1.1.0 here for 
+We import bats-core at SHA e582ef5 here, originally for 
 https://github.com/sobolevn/git-secret/issues/377,
 "Don't depend on network during builds (re: bats-core)"
 

--- a/vendor/bats-core/.appveyor.yml
+++ b/vendor/bats-core/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 'v1.1.0.{build}'
+version: 'v1.1.0+appveyor.{build}'
 
 build: off
 

--- a/vendor/bats-core/.editorconfig
+++ b/vendor/bats-core/.editorconfig
@@ -1,0 +1,32 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+# The JSON files contain newlines inconsistently
+[*.json]
+indent_size = 2
+insert_final_newline = ignore
+
+# YAML
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Makefiles always use tabs for recipe indentation
+[{Makefile,*.mak}]
+indent_style = tab
+
+# Markdown
+[*.{md,rmd,mkd,mkdn,mdwn,mdown,markdown,litcoffee}]
+max_line_length = 80
+# tabs behave as if they were replaced by spaces with a tab stop of 4 characters
+tab_width = 4
+# trailing spaces indicates word wrap
+trim_trailing_spaces = false
+trim_trailing_whitespace = false

--- a/vendor/bats-core/.travis.yml
+++ b/vendor/bats-core/.travis.yml
@@ -11,6 +11,7 @@ env:
   - BASHVER=4.2
   - BASHVER=4.3
   - BASHVER=4.4
+  - BASHVER=5
 
 matrix:
   include:
@@ -19,12 +20,23 @@ matrix:
 services:
   - docker
 
+before_script:
+ - |
+   if [[ "${TRAVIS_OS_NAME:-}" == 'linux' ]]; then
+     sudo apt-get install shellcheck
+   fi
+
 script:
 - |
-  if [[ "$TRAVIS_OS_NAME" == 'linux' && -n "$BASHVER" ]]; then
-    docker build --build-arg bashver=${BASHVER} --tag bats/bats:bash-${BASHVER} .
-    docker run -it bash:${BASHVER} --version
-    time docker run -it bats/bats:bash-${BASHVER} --tap /opt/bats/test
+  if [[ "${TRAVIS_OS_NAME:-}" == 'linux' ]]; then
+    # @todo: Remove "|| true" once all coding standards issues are fixed.
+    ./shellcheck.sh
+  fi
+
+  if [[ "${TRAVIS_OS_NAME:-}" == 'linux' && -n "${BASHVER}" ]]; then
+    docker build --build-arg bashver="${BASHVER}" --tag "bats/bats:bash-${BASHVER}" . &&
+      docker run -it "bash:${BASHVER}" --version &&
+      time docker run -it "bats/bats:bash-${BASHVER}" --tap /opt/bats/test
   else
     time bin/bats --tap test
   fi

--- a/vendor/bats-core/Dockerfile
+++ b/vendor/bats-core/Dockerfile
@@ -2,8 +2,12 @@ ARG bashver=latest
 
 FROM bash:${bashver}
 
-RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
+# Install parallel and accept the citation notice (we aren't using this in a
+# context where it make sense to cite GNU Parallel).
+RUN apk add --no-cache parallel && \
+    mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
+RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
 COPY . /opt/bats/
 
 ENTRYPOINT ["bash", "/usr/sbin/bats"]

--- a/vendor/bats-core/README.md
+++ b/vendor/bats-core/README.md
@@ -38,39 +38,39 @@ Test cases consist of standard shell commands. Bats makes use of Bash's
 test case exits with a `0` status code (success), the test passes. In this way,
 each line is an assertion of truth.
 
-**Tuesday, September 19, 2017:** This is a mirrored fork of [Bats][bats-orig] at
-commit [0360811][].  It was created via `git clone --bare` and `git push
---mirror`. See the [Background](#background) section below for more information.
-
-[bats-orig]: https://github.com/sstephenson/bats
-[0360811]: https://github.com/sstephenson/bats/commit/03608115df2071fff4eaaff1605768c275e5f81f
-
 ## Table of contents
 
+<!-- toc -->
+
 - [Installation](#installation)
-  - [Supported Bash versions](#supported-bash-versions)
-  - [Homebrew](#homebrew)
-  - [npm](#npm)
-  - [Installing Bats from source](#installing-bats-from-source)
-  - [Running Bats in Docker](#running-bats-in-docker)
-    - [Building a Docker image](#building-a-docker-image)
+  * [Supported Bash versions](#supported-bash-versions)
+  * [Homebrew](#homebrew)
+  * [npm](#npm)
+  * [Installing Bats from source](#installing-bats-from-source)
+  * [Installing Bats from source onto Windows Git Bash](#installing-bats-from-source-onto-windows-git-bash)
+  * [Running Bats in Docker](#running-bats-in-docker)
+    + [Building a Docker image](#building-a-docker-image)
 - [Usage](#usage)
 - [Writing tests](#writing-tests)
-  - [`run`: Test other commands](#run-test-other-commands)
-  - [`load`: Share common code](#load-share-common-code)
-  - [`skip`: Easily skip tests](#skip-easily-skip-tests)
-  - [`setup` and `teardown`: Pre- and post-test hooks](#setup-and-teardown-pre--and-post-test-hooks)
-  - [Code outside of test cases](#code-outside-of-test-cases)
-  - [File descriptor 3 (read this if Bats hangs)](#file-descriptor-3-read-this-if-bats-hangs)
-  - [Printing to the terminal](#printing-to-the-terminal)
-  - [Special variables](#special-variables)
+  * [`run`: Test other commands](#run-test-other-commands)
+  * [`load`: Share common code](#load-share-common-code)
+  * [`skip`: Easily skip tests](#skip-easily-skip-tests)
+  * [`setup` and `teardown`: Pre- and post-test hooks](#setup-and-teardown-pre--and-post-test-hooks)
+  * [Code outside of test cases](#code-outside-of-test-cases)
+  * [File descriptor 3 (read this if Bats hangs)](#file-descriptor-3-read-this-if-bats-hangs)
+  * [Printing to the terminal](#printing-to-the-terminal)
+  * [Special variables](#special-variables)
+- [Testing](#testing)
 - [Support](#support)
+- [Contributing](#contributing)
+- [Contact](#contact)
 - [Version history](#version-history)
 - [Background](#background)
-  - [Why was this fork created?](#why-was-this-fork-created)
-  - [What's the plan and why?](#whats-the-plan-and-why)
-  - [Contact us](#contact-us)
+  * [What's the plan and why?](#whats-the-plan-and-why)
+  * [Why was this fork created?](#why-was-this-fork-created)
 - [Copyright](#copyright)
+
+<!-- tocstop -->
 
 ## Installation
 
@@ -130,8 +130,18 @@ install Bats into `/usr/local`,
     $ cd bats-core
     $ ./install.sh /usr/local
 
-Note that you may need to run `install.sh` with `sudo` if you do not have
+__Note:__ You may need to run `install.sh` with `sudo` if you do not have
 permission to write to the installation prefix.
+
+### Installing Bats from source onto Windows Git Bash
+
+Check out a copy of the Bats repository and install it to `$HOME`. This
+will place the `bats` executable in `$HOME/bin`, which should already be
+in `$PATH`.
+
+    $ git clone https://github.com/bats-core/bats-core.git
+    $ cd bats-core
+    $ ./install.sh $HOME
 
 ### Running Bats in Docker
 
@@ -180,23 +190,29 @@ supports:
 
 ```
 Bats x.y.z
-Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]
+Usage: bats [-cr] [-f <regex>] [-j <jobs>] [-p | -t] <test>...
+       bats [-h | -v]
 
   <test> is the path to a Bats test file, or the path to a directory
-  containing Bats test files.
+  containing Bats test files (ending with ".bats").
 
   -c, --count      Count the number of test cases without running any tests
+  -f, --filter     Filter test cases by names matching the regular expression
   -h, --help       Display this help message
+  -j, --jobs       Number of parallel jobs to run (requires GNU parallel)
   -p, --pretty     Show results in pretty format (default for terminals)
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
   -v, --version    Display the version number
+
+  For more information, see https://github.com/bats-core/bats-core
 ```
+> **Mac OSX/Darwin Warning:** If you're executing bats directly (`bin/bats`) you need to `brew install coreutils` to obtain `greadlink`. Darwin's readlink does not include the -f option. This may be fixed [by this PR](https://github.com/bats-core/bats-core/pull/217), which needs reviewers.
 
 To run your tests, invoke the `bats` interpreter with one or more paths to test
 files ending with the `.bats` extension, or paths to directories containing test
-files. (`bats` will not only discover `.bats` files at the top level of each
-directory; it will not recurse.)
+files. (`bats` will only execute `.bats` files at the top level of each
+directory; it will not recurse unless you specify the `-r` flag.)
 
 Test cases from each file are run sequentially and in isolation. If all the test
 cases pass, `bats` exits with a `0` status code. If there are any failures,
@@ -222,6 +238,21 @@ option.
     1..2
     ok 1 addition using bc
     ok 2 addition using dc
+
+### Parallel Execution
+
+By default, Bats will execute your tests serially. However, Bats supports
+parallel execution of tests (provided you have [GNU parallel][gnu-parallel] or
+a compatible replacement installed) using the `--jobs` parameter. This can
+result in your tests completing faster (depending on your tests and the testing
+hardware).
+
+Ordering of parallised tests is not guaranteed, so this mode may break suites
+with dependencies between tests (or tests that write to shared locations). When
+enabling `--jobs` for the first time be sure to re-run bats multiple times to
+identify any inter-test dependencies or non-deterministic test behaviour.
+
+[gnu-parallel]: https://www.gnu.org/software/parallel/
 
 ## Writing tests
 
@@ -270,6 +301,10 @@ without any arguments prints usage information on the first line:
 }
 ```
 
+__Note:__ The `run` helper executes its argument(s) in a subshell, so if
+writing tests against environmental side-effects like a variable's value
+being changed, these changes will not persist after `run` completes.
+
 ### `load`: Share common code
 
 You may want to share common code across multiple test files. Bats includes a
@@ -283,6 +318,13 @@ load test_helper
 
 will source the script `test/test_helper.bash` in your test file. This can be
 useful for sharing functions to set up your environment or load fixtures.
+
+If you want to source a file using an absolute file path then the file extension
+must be included. For example
+
+```bash
+load /test_helpers/test_helper.bash
+```
 
 ### `skip`: Easily skip tests
 
@@ -320,6 +362,8 @@ Or you can skip conditionally:
 }
 ```
 
+__Note:__ `setup` and `teardown` hooks still run for skipped tests.
+
 ### `setup` and `teardown`: Pre- and post-test hooks
 
 You can define special `setup` and `teardown` functions, which run before and
@@ -354,7 +398,7 @@ service that will run indefinitely), Bats will be similarly blocked for the same
 amount of time.
 
 **To prevent this from happening, close FD 3 explicitly when running any command
-that may launch long-running child processes**, e.g. `command_name 3>- &`.
+that may launch long-running child processes**, e.g. `command_name 3>&-` .
 
 ### Printing to the terminal
 
@@ -418,6 +462,14 @@ There are several global variables you can use to introspect on Bats tests:
 * `$BATS_TMPDIR` is the location to a directory that may be used to store
   temporary files.
 
+## Testing
+
+```sh
+bin/bats --tap test
+```
+See also the [CI](.travis.yml) settings for the current test environment and
+scripts.
+
 ## Support
 
 The Bats source code repository is [hosted on
@@ -432,173 +484,48 @@ To learn how to set up your editor for Bats syntax highlighting, see [Syntax
 Highlighting](https://github.com/bats-core/bats-core/wiki/Syntax-Highlighting)
 on the wiki.
 
+## Contributing
+
+For now see the ``docs`` folder for project guides, work with us on the wiki
+or look at the other communication channels.
+
+## Contact
+
+- We are `#bats` on freenode;
+- Or leave a message on [gitter].
+
 ## Version history
 
-Bats is [SemVer compliant](https://semver.org/).
-
-*1.1.0* (July 8, 2018)
-
-This is the first release with new features relative to the original Bats 0.4.0.
-
-Added:
-* The `-r, --recursive` flag to scan directory arguments recursively for
-  `*.bats` files (#109)
-* The `contrib/rpm/bats.spec` file to build RPMs (#111)
-
-Changed:
-* Travis exercises latest versions of Bash from 3.2 through 4.4 (#116, #117)
-* Error output highlights invalid command line options (#45, #46, #118)
-* Replaced `echo` with `printf` (#120)
-
-Fixed:
-* Fixed `BATS_ERROR_STATUS` getting lost when `bats_error_trap` fired multiple
-  times under Bash 4.2.x (#110)
-* Updated `bin/bats` symlink resolution, handling the case on CentOS where
-  `/bin` is a symlink to `/usr/bin` (#113, #115)
-
-*1.0.2* (June 18, 2018)
-
-* Fixed sstephenson/bats#240, whereby `skip` messages containing parentheses
-  were truncated (#48)
-* Doc improvements:
-  * Docker usage (#94)
-  * Better README badges (#101)
-  * Better installation instructions (#102, #104)
-* Packaging/installation improvements:
-  * package.json update (#100)
-  * Moved `libexec/` files to `libexec/bats-core/`, improved `install.sh` (#105)
-
-*1.0.1* (June 9, 2018)
-
-* Fixed a `BATS_CWD` bug introduced in #91 whereby it was set to the parent of
-  `PWD`, when it should've been set to `PWD` itself (#98). This caused file
-  names in stack traces to contain the basename of `PWD` as a prefix, when the
-  names should've been purely relative to `PWD`.
-* Ensure the last line of test output prints when it doesn't end with a newline
-  (#99). This was a quasi-bug introduced by replacing `sed` with `while` in #88.
-
-*1.0.0* (June 8, 2018)
-
-`1.0.0` generally preserves compatibility with `0.4.0`, but with some Bash
-compatibility improvements and a massive performance boost. In other words:
-
-- all existing tests should remain compatible
-- tests that might've failed or exhibited unexpected behavior on earlier
-  versions of Bash should now also pass or behave as expected
-
-Changes:
-
-* Added support for Docker.
-* Added support for test scripts that have the [unofficial strict
-  mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) enabled.
-* Improved stability on Windows and macOS platforms.
-* Massive performance improvements, especially on Windows (#8)
-* Workarounds for inconsistent behavior between Bash versions (#82)
-* Workaround for preserving stack info after calling an exported function under
-  Bash < 4.4 (#87)
-* Fixed TAP compliance for skipped tests
-* Added support for tabs in test names.
-* `bin/bats` and `install.sh` now work reliably on Windows (#91)
-
-*0.4.0* (August 13, 2014)
-
-* Improved the display of failing test cases. Bats now shows the source code of
-  failing test lines, along with full stack traces including function names,
-  filenames, and line numbers.
-* Improved the display of the pretty-printed test summary line to include the
-  number of skipped tests, if any.
-* Improved the speed of the preprocessor, dramatically shortening test and suite
-  startup times.
-* Added support for absolute pathnames to the `load` helper.
-* Added support for single-line `@test` definitions.
-* Added bats(1) and bats(7) manual pages.
-* Modified the `bats` command to default to TAP output when the `$CI` variable
-  is set, to better support environments such as Travis CI.
-
-*0.3.1* (October 28, 2013)
-
-* Fixed an incompatibility with the pretty formatter in certain environments
-  such as tmux.
-* Fixed a bug where the pretty formatter would crash if the first line of a test
-  file's output was invalid TAP.
-
-*0.3.0* (October 21, 2013)
-
-* Improved formatting for tests run from a terminal. Failing tests are now
-  colored in red, and the total number of failing tests is displayed at the end
-  of the test run. When Bats is not connected to a terminal (e.g. in CI runs),
-  or when invoked with the `--tap` flag, output is displayed in standard TAP
-  format.
-* Added the ability to skip tests using the `skip` command.
-* Added a message to failing test case output indicating the file and line
-  number of the statement that caused the test to fail.
-* Added "ad-hoc" test suite support. You can now invoke `bats` with multiple
-  filename or directory arguments to run all the specified tests in aggregate.
-* Added support for test files with Windows line endings.
-* Fixed regular expression warnings from certain versions of Bash.
-* Fixed a bug running tests containing lines that begin with `-e`.
-
-*0.2.0* (November 16, 2012)
-
-* Added test suite support. The `bats` command accepts a directory name
-  containing multiple test files to be run in aggregate.
-* Added the ability to count the number of test cases in a file or suite by
-  passing the `-c` flag to `bats`.
-* Preprocessed sources are cached between test case runs in the same file for
-  better performance.
-
-*0.1.0* (December 30, 2011)
-
-* Initial public release.
-
----
+See `docs/CHANGELOG.md`.
 
 ## Background
 
-### Why was this fork created?
-
-The original Bats repository needed new maintainers, and has not been actively
-maintained since 2013. While there were volunteers for maintainers, attempts to
-organize issues, and outstanding PRs, the lack of write-access to the repo
-hindered progress severely.
-
 ### What's the plan and why?
 
-The rough plan, originally [outlined
-here](https://github.com/sstephenson/bats/issues/150#issuecomment-323845404) is
-to create a new, mirrored mainline (this repo!). An excerpt:
+**Tuesday, September 19, 2017:** This was forked from [Bats][bats-orig] at
+commit [0360811][].  It was created via `git clone --bare` and `git push
+--mirror`. See the [Background](#background) section above for more information.
 
-> **1. Roadmap 1.0:**
-> There are already existing high-quality PRs, and often-requested features and
-> issues, especially here at
-> [#196](https://github.com/sstephenson/bats/issues/196). Leverage these and
-> **consolidate into a single roadmap**.
->
-> **2. Create or choose a fork or *mirror* of this repo to use as the new
-> mainline:**
-> Repoint existing PRs (whichever ones are possible) to the new mainline, get
-> that repo to a stable 1.0. IMO we should create an organization and grant 2-3
-> people admin and write access.
+[bats-orig]: https://github.com/sstephenson/bats
+[0360811]: https://github.com/sstephenson/bats/commit/03608115df2071fff4eaaff1605768c275e5f81f
 
-Doing it this way accomplishes a number of things:
+This [bats-core repo](https://github.com/bats-core/bats-core) is the community-maintained Bats project.
 
-1. Removes the dependency on the original maintainer
-1. Enables collaboration and contribution flow again
-1. Allows the possibility of merging back to original, or merging from original
-   if or when the need arises
-1. Prevents lock-out by giving administrative access to more than one person,
-   increases transferability
+### Why was this fork created?
 
-### Contact us
+There was an initial [call for maintainers][call-maintain] for the original Bats repository, but write access to it could not be obtained. With development activity stalled, this fork allowed ongoing maintenance and forward progress for Bats.
 
-- We are `#bats` on freenode
+[call-maintain]: https://github.com/sstephenson/bats/issues/150
 
 ## Copyright
 
-© 2018 bats-core organization
+© 2017-2018 bats-core organization
 
-© 2014 Sam Stephenson
+© 2011-2016 Sam Stephenson
 
 Bats is released under an MIT-style license; see `LICENSE.md` for details.
+
+See the [parent project](https://github.com/bats-core) at GitHub or the
+[AUTHORS](AUTHORS) file for the current project maintainer team.
 
 [gitter]: https://gitter.im/bats-core/bats-core?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/vendor/bats-core/bin/bats
+++ b/vendor/bats-core/bin/bats
@@ -2,18 +2,12 @@
 
 set -e
 
-export BATS_READLINK='true'
+BATS_READLINK='true'
 if command -v 'greadlink' >/dev/null; then
   BATS_READLINK='greadlink'
 elif command -v 'readlink' >/dev/null; then
   BATS_READLINK='readlink'
 fi
-
-bats_resolve_link() {
-  if ! "$BATS_READLINK" "$1"; then
-    return 0
-  fi
-}
 
 bats_resolve_absolute_root_dir() {
   local cwd="$PWD"
@@ -35,7 +29,7 @@ bats_resolve_absolute_root_dir() {
     fi
 
     if [[ -L "$target_name" ]]; then
-      path="$(bats_resolve_link "$target_name")"
+      path="$("$BATS_READLINK" "$target_name")"
     else
       printf -v "$result" -- '%s' "${PWD%/*}"
       set +P "-$original_shell_options"

--- a/vendor/bats-core/docs/CHANGELOG.md
+++ b/vendor/bats-core/docs/CHANGELOG.md
@@ -1,0 +1,151 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog][kac] and this project adheres to
+[Semantic Versioning][semver].
+
+[kac]: https://keepachangelog.com/en/1.0.0/
+[semver]: https://semver.org/
+
+## [Unreleased]
+
+### Added
+* docs/CHANGELOG.md and docs/releasing.md (#122)
+* The `-f, --filter` flag to run only the tests matching a regular expression  (#126)
+* Optimize stack trace capture (#138)
+* `--jobs n` flag to support parallel execution of tests with GNU parallel (#172)
+
+### Changed
+* AppVeyor builds are now semver-compliant (#123)
+* Add Bash 5 as test target (#181)
+* Always use upper case signal names to avoid locale dependent err… (#215)
+* Fix for tests reading from stdin (#227)
+* Fix wrong line numbers of errors in bash < 4.4 (#229)
+* Remove preprocessed source after test run (#232)
+
+## [1.1.0] - 2018-07-08
+
+This is the first release with new features relative to the original Bats 0.4.0.
+
+### Added
+* The `-r, --recursive` flag to scan directory arguments recursively for
+  `*.bats` files (#109)
+* The `contrib/rpm/bats.spec` file to build RPMs (#111)
+
+### Changed
+* Travis exercises latest versions of Bash from 3.2 through 4.4 (#116, #117)
+* Error output highlights invalid command line options (#45, #46, #118)
+* Replaced `echo` with `printf` (#120)
+
+### Fixed
+* Fixed `BATS_ERROR_STATUS` getting lost when `bats_error_trap` fired multiple
+  times under Bash 4.2.x (#110)
+* Updated `bin/bats` symlink resolution, handling the case on CentOS where
+  `/bin` is a symlink to `/usr/bin` (#113, #115)
+
+## [1.0.2] - 2018-06-18
+
+* Fixed sstephenson/bats#240, whereby `skip` messages containing parentheses
+  were truncated (#48)
+* Doc improvements:
+  * Docker usage (#94)
+  * Better README badges (#101)
+  * Better installation instructions (#102, #104)
+* Packaging/installation improvements:
+  * package.json update (#100)
+  * Moved `libexec/` files to `libexec/bats-core/`, improved `install.sh` (#105)
+
+## [1.0.1] - 2018-06-09
+
+* Fixed a `BATS_CWD` bug introduced in #91 whereby it was set to the parent of
+  `PWD`, when it should've been set to `PWD` itself (#98). This caused file
+  names in stack traces to contain the basename of `PWD` as a prefix, when the
+  names should've been purely relative to `PWD`.
+* Ensure the last line of test output prints when it doesn't end with a newline
+  (#99). This was a quasi-bug introduced by replacing `sed` with `while` in #88.
+
+## [1.0.0] - 2018-06-08
+
+`1.0.0` generally preserves compatibility with `0.4.0`, but with some Bash
+compatibility improvements and a massive performance boost. In other words:
+
+- all existing tests should remain compatible
+- tests that might've failed or exhibited unexpected behavior on earlier
+  versions of Bash should now also pass or behave as expected
+
+Changes:
+
+* Added support for Docker.
+* Added support for test scripts that have the [unofficial strict
+  mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) enabled.
+* Improved stability on Windows and macOS platforms.
+* Massive performance improvements, especially on Windows (#8)
+* Workarounds for inconsistent behavior between Bash versions (#82)
+* Workaround for preserving stack info after calling an exported function under
+  Bash < 4.4 (#87)
+* Fixed TAP compliance for skipped tests
+* Added support for tabs in test names.
+* `bin/bats` and `install.sh` now work reliably on Windows (#91)
+
+## [0.4.0] - 2014-08-13
+
+* Improved the display of failing test cases. Bats now shows the source code of
+  failing test lines, along with full stack traces including function names,
+  filenames, and line numbers.
+* Improved the display of the pretty-printed test summary line to include the
+  number of skipped tests, if any.
+* Improved the speed of the preprocessor, dramatically shortening test and suite
+  startup times.
+* Added support for absolute pathnames to the `load` helper.
+* Added support for single-line `@test` definitions.
+* Added bats(1) and bats(7) manual pages.
+* Modified the `bats` command to default to TAP output when the `$CI` variable
+  is set, to better support environments such as Travis CI.
+
+## [0.3.1] - 2013-10-28
+
+* Fixed an incompatibility with the pretty formatter in certain environments
+  such as tmux.
+* Fixed a bug where the pretty formatter would crash if the first line of a test
+  file's output was invalid TAP.
+
+## [0.3.0] - 2013-10-21
+
+* Improved formatting for tests run from a terminal. Failing tests are now
+  colored in red, and the total number of failing tests is displayed at the end
+  of the test run. When Bats is not connected to a terminal (e.g. in CI runs),
+  or when invoked with the `--tap` flag, output is displayed in standard TAP
+  format.
+* Added the ability to skip tests using the `skip` command.
+* Added a message to failing test case output indicating the file and line
+  number of the statement that caused the test to fail.
+* Added "ad-hoc" test suite support. You can now invoke `bats` with multiple
+  filename or directory arguments to run all the specified tests in aggregate.
+* Added support for test files with Windows line endings.
+* Fixed regular expression warnings from certain versions of Bash.
+* Fixed a bug running tests containing lines that begin with `-e`.
+
+## [0.2.0] - 2012-11-16
+
+* Added test suite support. The `bats` command accepts a directory name
+  containing multiple test files to be run in aggregate.
+* Added the ability to count the number of test cases in a file or suite by
+  passing the `-c` flag to `bats`.
+* Preprocessed sources are cached between test case runs in the same file for
+  better performance.
+
+## [0.1.0] - 2011-12-30
+
+* Initial public release.
+
+[Unreleased]: https://github.com/bats-core/bats-core/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/bats-core/bats-core/compare/v1.0.2...v1.1.0
+[1.0.2]: https://github.com/bats-core/bats-core/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/bats-core/bats-core/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/bats-core/bats-core/compare/v0.4.0...v1.0.0
+[0.4.0]: https://github.com/bats-core/bats-core/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/bats-core/bats-core/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/bats-core/bats-core/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/bats-core/bats-core/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/bats-core/bats-core/commits/v0.1.0

--- a/vendor/bats-core/docs/CONTRIBUTING.md
+++ b/vendor/bats-core/docs/CONTRIBUTING.md
@@ -336,6 +336,21 @@ The following are intended to prevent too-compact code:
 
 [printf-vs-echo]: https://unix.stackexchange.com/a/65819
 
+### Signal names
+
+Always use upper case signal names (e.g. `trap - INT EXIT`) to avoid locale 
+dependent errors. In some locales (for example Turkish, see 
+[Turkish dotless i](https://en.wikipedia.org/wiki/Dotted_and_dotless_I)) lower 
+case signal names cause Bash to error. An example of the problem:
+
+```bash
+$ echo "tr_TR.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen tr_TR.UTF-8 # Ubuntu derivatives
+$ LC_CTYPE=tr_TR.UTF-8 LC_MESSAGES=C bash -c 'trap - int && echo success'
+bash: line 0: trap: int: invalid signal specification
+$ LC_CTYPE=tr_TR.UTF-8 LC_MESSAGES=C bash -c 'trap - INT && echo success'
+success
+```
+
 ### Gotchas
 
 - If you wish to use command substitution to initialize a `local` variable, and

--- a/vendor/bats-core/docs/releasing.md
+++ b/vendor/bats-core/docs/releasing.md
@@ -1,0 +1,128 @@
+# Releasing a new Bats version
+
+These notes reflect the current process. There's a lot more we could do, in
+terms of automation and expanding the number of platforms to which we formally
+release (see #103).
+
+## Update docs/CHANGELOG.md
+
+Create a new entry at the top of `docs/CHANGELOG.md` that enumerates the
+significant updates to the new version.
+
+## Bumping the version number
+
+Bump the version numbers in the following files:
+
+- .appveyor.yml
+- contrib/rpm/bats.spec
+- libexec/bats-core/bats
+- package.json
+
+Commit these changes (including the `docs/CHANGELOG.md` changes) in a commit
+with the message `Bats <VERSION>`, where `<VERSION>` is the new version number.
+
+Create a new signed, annotated tag with:
+
+```bash
+$ git tag -a -s <VERSION>
+```
+
+Include the `docs/CHANGELOG.md` notes corresponding to the new version as the
+tag annotation, except the first line should be: `Bats <VERSION> - YYYY-MM-DD`
+and any Markdown headings should become plain text, e.g.:
+
+```md
+### Added
+```
+
+should become:
+
+```md
+Added:
+```
+
+## Create a GitHub release
+
+Push the new version commit and tag to GitHub via the following:
+
+```bash
+$ git push --follow-tags
+```
+
+Then visit https://github.com/bats-core/bats-core/releases, and:
+
+* Click **Draft a new release**.
+* Select the new version tag.
+* Name the release: `Bats <VERSION>`.
+* Paste the same notes from the version tag annotation as the description,
+  except change the first line to read: `Released: YYYY-MM-DD`.
+* Click **Publish release**.
+
+For more on `git push --follow-tags`, see:
+
+* [git push --follow-tags in the online manual][ft-man]
+* [Stack Overflow: How to push a tag to a remote repository using Git?][ft-so]
+
+[ft-man]: https://git-scm.com/docs/git-push#git-push---follow-tags
+[ft-so]: https://stackoverflow.com/a/26438076
+
+## NPM
+
+`npm publish`. Pretty easy!
+
+For the paranoid, use `npm pack` and install the resulting tarball locally with
+`npm install` before publishing.
+
+## Homebrew
+
+The basic instructions are in the [Submit a new version of an existing
+formula][brew] section of the Homebrew docs.
+
+[brew]: https://github.com/Homebrew/brew/blob/master/docs/How-To-Open-a-Homebrew-Pull-Request.md#submit-a-new-version-of-an-existing-formula
+
+An example using v1.1.0 (notice that this uses the sha256 sum of the tarball):
+
+```bash
+$ curl -LOv https://github.com/bats-core/bats-core/archive/v1.1.0.tar.gz
+$ openssl sha256 v1.1.0.tar.gz
+SHA256(v1.1.0.tar.gz)=855d8b8bed466bc505e61123d12885500ef6fcdb317ace1b668087364717ea82
+
+# Add the --dry-run flag to see the individual steps without executing.
+$ brew bump-formula-pr \
+  --url=https://github.com/bats-core/bats-core/archive/v1.1.0.tar.gz \
+  --sha256=855d8b8bed466bc505e61123d12885500ef6fcdb317ace1b668087364717ea82
+```
+This resulted in https://github.com/Homebrew/homebrew-core/pull/29864, which was
+automatically merged once the build passed.
+
+## Alpine Linux
+
+An example using v1.1.0 (notice that this uses the sha512 sum of the Zip file):
+
+```bash
+$ curl -LOv https://github.com/bats-core/bats-core/archive/v1.1.0.zip
+$ openssl sha512 v1.1.0.zip
+SHA512(v1.1.0.zip)=accd83cfec0025a2be40982b3f9a314c2bbf72f5c85daffa9e9419611904a8d34e376919a5d53e378382e0f3794d2bd781046d810225e2a77812474e427bed9e
+```
+
+After cloning alpinelinux/aports, I used the above information to create:
+https://github.com/alpinelinux/aports/pull/4696
+
+**Note:** Currently users must enable the `edge` branch of the `community` repo
+by adding/uncommenting the corresponding entry in `/etc/apk/repositories`.
+
+## Announce
+
+It's worth making a brief announcement like [the v1.1.0 announcement via
+Gitter][gitter]:
+
+[gitter]: https://gitter.im/bats-core/bats-core?at=5b42c9a57b811a6d63daacb5
+
+```
+v1.1.0 is now available via Homebrew and npm:
+https://github.com/bats-core/bats-core/releases/tag/v1.1.0
+
+It'll eventually be available in Alpine via the edge branch of the community
+repo once alpinelinux/aports#4696 gets merged. (Check /etc/apk/repositories to
+ensure this repo is enabled.)
+```

--- a/vendor/bats-core/libexec/bats-core/bats
+++ b/vendor/bats-core/libexec/bats-core/bats
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-version() {
-  printf 'Bats 1.1.0\n'
-}
+export BATS_VERSION='1.2.0-dev'
 
-usage() {
-  version
-  printf 'Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]\n'
+version() {
+  printf 'Bats %s\n' "$BATS_VERSION"
 }
 
 abort() {
@@ -16,18 +13,23 @@ abort() {
   exit 1
 }
 
-help() {
+usage() {
+  local cmd="${0##*/}"
   local line
-  usage
-  while read -r line; do
+
+  while IFS= read -r line; do
     printf '%s\n' "$line"
   done <<END_OF_HELP_TEXT
+Usage: $cmd [-cr] [-f <regex>] [-j <jobs>] [-p | -t] <test>...
+       $cmd [-h | -v]
 
   <test> is the path to a Bats test file, or the path to a directory
-  containing Bats test files.
+  containing Bats test files (ending with ".bats").
 
   -c, --count      Count the number of test cases without running any tests
+  -f, --filter     Filter test cases by names matching the regular expression
   -h, --help       Display this help message
+  -j, --jobs       Number of parallel jobs to run (requires GNU parallel)
   -p, --pretty     Show results in pretty format (default for terminals)
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
@@ -36,6 +38,11 @@ help() {
   For more information, see https://github.com/bats-core/bats-core
 
 END_OF_HELP_TEXT
+}
+
+expand_link() {
+  readlink="$(type -p greadlink readlink | head -1)"
+  "$readlink" -f "$1"
 }
 
 expand_path() {
@@ -53,68 +60,81 @@ expand_path() {
   printf -v "$result" '%s/%s' "$dirname" "${path##*/}"
 }
 
+BATS_LIBEXEC="$(dirname "$(expand_link "${BASH_SOURCE[0]}")")"
 export BATS_CWD="$PWD"
 export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
-export PATH="$BATS_ROOT/libexec/bats-core:$PATH"
+export BATS_TEST_FILTER=
+export PATH="$BATS_LIBEXEC:$PATH"
 
-options=()
 arguments=()
+
+# Unpack single-character options bundled together, e.g. -cr, -pr.
 for arg in "$@"; do
-  if [[ "${arg:0:1}" = "-" ]]; then
-    if [[ "${arg:1:1}" = "-" ]]; then
-      options[${#options[*]}]="${arg:2}"
-    else
-      index=1
-      while option="${arg:$index:1}"; do
-        if [[ -z "$option" ]]; then
-          break
-        fi
-        options[${#options[*]}]="$option"
-        let index+=1
-      done
-    fi
+  if [[ "$arg" =~ ^-[^-]. ]]; then
+    index=1
+    while option="${arg:$((index++)):1}"; do
+      if [[ -z "$option" ]]; then
+        break
+      fi
+      arguments+=("-$option")
+    done
   else
-    arguments[${#arguments[*]}]="$arg"
+    arguments+=("$arg")
   fi
+  shift
 done
 
-unset count_flag pretty recursive
-count_flag=''
-pretty=''
-recursive=''
-if [[ -z "${CI:-}" && -t 0 && -t 1 ]]; then
+set -- "${arguments[@]}"
+arguments=()
+
+unset flags pretty recursive
+flags=()
+pretty=
+recursive=
+if [[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput >/dev/null; then
   pretty=1
 fi
 
-if [[ "${#options[@]}" -ne 0 ]]; then
-  for option in "${options[@]}"; do
-    case "$option" in
-    "h" | "help" )
-      help
-      exit 0
-      ;;
-    "v" | "version" )
-      version
-      exit 0
-      ;;
-    "c" | "count" )
-      count_flag="-c"
-      ;;
-    "r" | "recursive" )
-      recursive=1
-      ;;
-    "t" | "tap" )
-      pretty=""
-      ;;
-    "p" | "pretty" )
-      pretty=1
-      ;;
-    * )
-      abort "Bad command line option '-$option'"
-      ;;
-    esac
-  done
-fi
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  -h|--help)
+    version
+    usage
+    exit 0
+    ;;
+  -v|--version)
+    version
+    exit 0
+    ;;
+  -c|--count)
+    flags+=('-c')
+    ;;
+  -f|--filter)
+    shift
+    flags+=('-f' "$1")
+    ;;
+  -j|--jobs)
+    shift
+    flags+=('-j' "$1")
+    ;;
+  -r|--recursive)
+    recursive=1
+    ;;
+  -t|--tap)
+    pretty=
+    ;;
+  -p|--pretty)
+    pretty=1
+    ;;
+  -*)
+    abort "Bad command line option '$1'"
+    ;;
+  *)
+    arguments+=("$1")
+    ;;
+  esac
+  shift
+done
 
 if [[ "${#arguments[@]}" -eq 0 ]]; then
   abort 'Must specify at least one <test>'
@@ -128,31 +148,24 @@ for filename in "${arguments[@]}"; do
     shopt -s nullglob
     if [[ "$recursive" -eq 1 ]]; then
       while IFS= read -r -d $'\0' file; do
-        filenames["${#filenames[@]}"]="$file"
-      done < <(find "$filename" -type f -name "*.bats" -print0 | sort -z)
+        filenames+=("$file")
+      done < <(find "$filename" -type f -name '*.bats' -print0 | sort -z)
     else
       for suite_filename in "$filename"/*.bats; do
-        filenames["${#filenames[@]}"]="$suite_filename"
+        filenames+=("$suite_filename")
       done
     fi
     shopt -u nullglob
   else
-    filenames["${#filenames[@]}"]="$filename"
+    filenames+=("$filename")
   fi
 done
 
-if [[ "${#filenames[@]}" -eq 1 ]]; then
-  command="bats-exec-test"
-else
-  command="bats-exec-suite"
+formatter="cat"
+if [[ -n "$pretty" ]]; then
+  flags+=("-x")
+  formatter="bats-format-tap-stream"
 fi
 
 set -o pipefail execfail
-if [[ -z "$pretty" ]]; then
-  exec "$command" $count_flag "${filenames[@]}"
-else
-  extended_syntax_flag="-x"
-  formatter="bats-format-tap-stream"
-  exec "$command" $count_flag $extended_syntax_flag "${filenames[@]}" |
-    "$formatter"
-fi
+exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | "$formatter"

--- a/vendor/bats-core/libexec/bats-core/bats-exec-suite
+++ b/vendor/bats-core/libexec/bats-core/bats-exec-suite
@@ -1,63 +1,114 @@
 #!/usr/bin/env bash
 set -e
 
-count_only_flag=""
-if [[ "$1" = "-c" ]]; then
-  count_only_flag=1
+count_only_flag=''
+extended_syntax_flag=''
+filter=''
+num_jobs=1
+have_gnu_parallel=
+flags=()
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  -c)
+    count_only_flag=1
+    ;;
+  -f)
+    shift
+    filter="$1"
+    flags+=('-f' "$filter")
+    ;;
+  -j)
+    shift
+    num_jobs="$1"
+    ;;
+  -x)
+    # shellcheck disable=SC2034
+    extended_syntax_flag='-x'
+    flags+=('-x')
+    ;;
+  *)
+    break
+    ;;
+  esac
   shift
-fi
-
-extended_syntax_flag=""
-if [[ "$1" = "-x" ]]; then
-  extended_syntax_flag="-x"
-  shift
-fi
-
-trap "kill 0; exit 1" int
-
-count=0
-for filename in "$@"; do
-  while IFS= read -r line; do
-    if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
-      let count+=1
-    fi
-  done <"$filename"
 done
 
+if ( type -p parallel &>/dev/null ); then
+  # shellcheck disable=SC2034
+  have_gnu_parallel=1
+elif [[ "$num_jobs" != 1 ]]; then
+  printf 'bats: cannot execute "%s" jobs without GNU parallel\n' "$num_jobs" >&2
+  exit 1
+fi
+
+trap 'kill 0; exit 1' INT
+
+all_tests=()
+for filename in "$@"; do
+  if  [[ ! -f "$filename" ]]; then
+    printf 'bats: %s does not exist\n' "$filename" >&2
+    exit 1
+  fi
+
+  test_names=()
+  test_dupes=()
+  while read -r line; do
+    if [[ ! "$line" =~ ^bats_test_function\  ]]; then
+      continue
+    fi
+    line="${line%$'\r'}"
+    line="${line#* }"
+
+    all_tests+=( "$(printf "%s\t%s" "$filename" "$line")" )
+    if [[ " ${test_names[*]} " == *" $line "* ]]; then
+      test_dupes+=("$line")
+      continue
+    fi
+    test_names+=("$line")
+  done < <(BATS_TEST_FILTER="$filter" bats-preprocess "$filename")
+
+  if [[ "${#test_dupes[@]}" -ne 0 ]]; then
+    printf 'bats warning: duplicate test name(s) in %s: %s\n' "$filename" "${test_dupes[*]}" >&2
+  fi
+done
+
+test_count="${#all_tests[@]}"
+
 if [[ -n "$count_only_flag" ]]; then
-  printf '%d\n' "$count"
+  printf '%d\n' "${test_count}"
   exit
 fi
 
-printf '1..%d\n' "$count"
 status=0
-offset=0
-for filename in "$@"; do
-  index=0
-  {
-    IFS= read -r # 1..n
-    while IFS= read -r line; do
-      case "$line" in
-      "begin "* )
-        let index+=1
-        printf '%s\n' "${line/ $index / $(($offset + $index)) }"
-        ;;
-      "ok "* | "not ok "* )
-        if [[ -z "$extended_syntax_flag" ]]; then
-          let index+=1
-        fi
-        printf '%s\n' "${line/ $index / $(($offset + $index)) }"
-        if [[ "${line:0:6}" == "not ok" ]]; then
-          status=1
-        fi
-        ;;
-      * )
-        printf '%s\n' "$line"
-        ;;
-      esac
-    done
-  } < <( bats-exec-test $extended_syntax_flag "$filename" )
-  offset=$(($offset + $index))
-done
+printf '1..%d\n' "${test_count}"
 
+# No point on continuing if there's no tests.
+if [[ "${test_count}" == 0 ]]; then
+  exit
+fi
+
+if [[ "$num_jobs" != 1 ]]; then
+  # Only use GNU parallel when we want parallel execution -- there is a small
+  # amount of overhead using it over a simple loop in the serial case.
+  set -o pipefail
+  printf '%s\n' "${all_tests[@]}" | grep -v '^$' | \
+    parallel -qk -j "$num_jobs" --colsep="\t" -- bats-exec-test "${flags[@]}" '{1}' '{2}' '{#}' || status=1
+else
+  # Just do it serially.
+  test_number=0
+  for test_line in "${all_tests[@]}"; do
+    # Only handle non-empty lines
+    if [[ $test_line ]]; then
+      filename="${test_line%%$'\t'*}"
+      test_name="${test_line##*$'\t'}"
+      ((++test_number))
+      bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number" || status=1
+    fi
+  done
+  if [[ "${test_number}" != "${test_count}" ]]; then
+    printf '# bats warning: Only executed %s of %s tests\n' "$test_number" "$test_count"
+    status=1
+  fi
+fi
 exit "$status"

--- a/vendor/bats-core/libexec/bats-core/bats-exec-test
+++ b/vendor/bats-core/libexec/bats-core/bats-exec-test
@@ -1,27 +1,40 @@
 #!/usr/bin/env bash
 set -eET
 
-BATS_COUNT_ONLY=""
-if [[ "$1" = "-c" ]]; then
-  BATS_COUNT_ONLY=1
-  shift
-fi
+# Variables used in other scripts.
+BATS_COUNT_ONLY=''
+BATS_TEST_FILTER=''
+BATS_EXTENDED_SYNTAX=''
 
-BATS_EXTENDED_SYNTAX=""
-if [[ "$1" = "-x" ]]; then
-  BATS_EXTENDED_SYNTAX="$1"
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+  -c)
+    # shellcheck disable=SC2034
+    BATS_COUNT_ONLY=1
+    ;;
+  -f)
+    shift
+    # shellcheck disable=SC2034
+    BATS_TEST_FILTER="$1"
+    ;;
+  -x)
+    BATS_EXTENDED_SYNTAX='-x'
+    ;;
+  *)
+    break
+    ;;
+  esac
   shift
-fi
+done
 
 BATS_TEST_FILENAME="$1"
+shift
 if [[ -z "$BATS_TEST_FILENAME" ]]; then
   printf 'usage: bats-exec-test <filename>\n' >&2
   exit 1
 elif [[ ! -f "$BATS_TEST_FILENAME" ]]; then
   printf 'bats: %s does not exist\n' "$BATS_TEST_FILENAME" >&2
   exit 1
-else
-  shift
 fi
 
 BATS_TEST_DIRNAME="${BATS_TEST_FILENAME%/*}"
@@ -31,7 +44,7 @@ load() {
   local name="$1"
   local filename
 
-  if [[ "${name:0:1}" = "/" ]]; then
+  if [[ "${name:0:1}" == '/' ]]; then
     filename="${name}"
   else
     filename="$BATS_TEST_DIRNAME/${name}.bash"
@@ -42,6 +55,8 @@ load() {
     exit 1
   fi
 
+  # Dynamically loaded user files provided outside of Bats.
+  # shellcheck disable=SC1090
   source "${filename}"
 }
 
@@ -49,8 +64,12 @@ run() {
   local origFlags="$-"
   set +eET
   local origIFS="$IFS"
+  # 'output', 'status', 'lines' are global variables available to tests.
+  # shellcheck disable=SC2034
   output="$("$@" 2>&1)"
+  # shellcheck disable=SC2034
   status="$?"
+  # shellcheck disable=SC2034,SC2206
   IFS=$'\n' lines=($output)
   IFS="$origIFS"
   set "-$origFlags"
@@ -64,7 +83,6 @@ teardown() {
   return 0
 }
 
-BATS_TEST_SKIPPED=''
 skip() {
   BATS_TEST_SKIPPED="${1:-1}"
   BATS_TEST_COMPLETED=1
@@ -84,39 +102,27 @@ bats_test_function() {
   BATS_TEST_NAMES+=("$test_name")
 }
 
-BATS_CURRENT_STACK_TRACE=()
-BATS_PREVIOUS_STACK_TRACE=()
-BATS_ERROR_STACK_TRACE=()
-
 bats_capture_stack_trace() {
-  if [[ "${#BATS_CURRENT_STACK_TRACE[@]}" -ne 0 ]]; then
-    BATS_PREVIOUS_STACK_TRACE=("${BATS_CURRENT_STACK_TRACE[@]}")
-  fi
-  BATS_CURRENT_STACK_TRACE=()
-
-  local test_pattern=" $BATS_TEST_NAME $BATS_TEST_SOURCE"
-  local setup_pattern=" setup $BATS_TEST_SOURCE"
-  local teardown_pattern=" teardown $BATS_TEST_SOURCE"
-
-  local source_file
-  local frame
+  local test_file
+  local funcname
   local i
+
+  BATS_STACK_TRACE=()
 
   for ((i=2; i != ${#FUNCNAME[@]}; ++i)); do
     # Use BATS_TEST_SOURCE if necessary to work around Bash < 4.4 bug whereby
     # calling an exported function erases the test file's BASH_SOURCE entry.
-    source_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
-    frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} $source_file"
-    BATS_CURRENT_STACK_TRACE["${#BATS_CURRENT_STACK_TRACE[@]}"]="$frame"
-    if [[ "$frame" = *"$test_pattern"     || \
-          "$frame" = *"$setup_pattern"    || \
-          "$frame" = *"$teardown_pattern" ]]; then
-      break
+    test_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
+    funcname="${FUNCNAME[$i]}"
+    BATS_STACK_TRACE+=("${BASH_LINENO[$((i-1))]} $funcname $test_file")
+    if [[ "$test_file" == "$BATS_TEST_SOURCE" ]]; then
+      case "$funcname" in
+      "$BATS_TEST_NAME"|setup|teardown)
+        break
+        ;;
+      esac
     fi
   done
-
-  bats_frame_filename "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_SOURCE'
-  bats_frame_lineno "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_LINENO'
 }
 
 bats_print_stack_trace() {
@@ -149,13 +155,12 @@ bats_print_stack_trace() {
       printf 'in file %s, line %d,\n' "$filename" "$lineno"
     fi
 
-    let index+=1
+    ((++index))
   done
 }
 
 bats_print_failed_command() {
-  local frame="$1"
-  local status="$2"
+  local frame="${BATS_STACK_TRACE[${#BATS_STACK_TRACE[@]}-1]}"
   local filename
   local lineno
   local failed_line
@@ -167,10 +172,10 @@ bats_print_failed_command() {
   bats_strip_string "$failed_line" 'failed_command'
   printf '%s' "#   \`${failed_command}' "
 
-  if [[ $status -eq 1 ]]; then
+  if [[ "$BATS_ERROR_STATUS" -eq 1 ]]; then
     printf 'failed\n'
   else
-    printf 'failed with status %d\n' "$status"
+    printf 'failed with status %d\n' "$BATS_ERROR_STATUS"
   fi
 }
 
@@ -187,7 +192,7 @@ bats_frame_filename() {
   local __bff_filename="${1#* }"
   __bff_filename="${__bff_filename#* }"
 
-  if [[ "$__bff_filename" = "$BATS_TEST_SOURCE" ]]; then
+  if [[ "$__bff_filename" == "$BATS_TEST_SOURCE" ]]; then
     __bff_filename="$BATS_TEST_FILENAME"
   fi
   printf -v "$2" '%s' "$__bff_filename"
@@ -215,7 +220,13 @@ bats_trim_filename() {
 }
 
 bats_debug_trap() {
-  if [[ "$BASH_SOURCE" != "$1" ]]; then
+  if [[ "${BASH_SOURCE[0]}" != "$1" ]]; then
+    # The last entry in the stack trace is not useful when en error occured:
+    # It is either duplicated (kinda correct) or has wrong line number (Bash < 4.4)
+    # Therefore we capture the stacktrace but use it only after the next debug
+    # trap fired.
+    # Expansion is required for empty arrays which otherwise error
+    BATS_CURRENT_STACK_TRACE=( "${BATS_STACK_TRACE[@]+"${BATS_STACK_TRACE[@]}"}" )
     bats_capture_stack_trace
   fi
 }
@@ -225,10 +236,9 @@ bats_debug_trap() {
 # set `$?` properly. See #72 and #81 for details.
 #
 # For this reason, we call `bats_error_trap` at the very beginning of
-# `bats_teardown_trap` (the `DEBUG` trap for the call will move
-# `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the value
-# of `$BATS_TEST_COMPLETED` before taking other actions. We also adjust the exit
-# status value if needed.
+# `bats_teardown_trap` (the `DEBUG` trap for the call will fix the stack trace)
+# and check the value of `$BATS_TEST_COMPLETED` before taking other actions.
+# We also adjust the exit status value if needed.
 #
 # See `bats_exit_trap` for an additional EXIT error handling case when `$?`
 # isn't set properly during `teardown()` errors.
@@ -239,8 +249,8 @@ bats_error_trap() {
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       BATS_ERROR_STATUS=1
     fi
-    BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
-    trap - debug
+    BATS_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
+    trap - DEBUG
   fi
 }
 
@@ -253,7 +263,6 @@ bats_teardown_trap() {
     BATS_TEARDOWN_COMPLETED=1
   elif [[ -n "$BATS_TEST_COMPLETED" ]]; then
     BATS_ERROR_STATUS="$status"
-    BATS_ERROR_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
   fi
 
   bats_exit_trap
@@ -263,17 +272,17 @@ bats_exit_trap() {
   local line
   local status
   local skipped=''
-  trap - err exit
+  trap - ERR EXIT
 
   if [[ -n "$BATS_TEST_SKIPPED" ]]; then
-    skipped=" # skip"
+    skipped=' # skip'
     if [[ "$BATS_TEST_SKIPPED" != '1' ]]; then
       skipped+=" $BATS_TEST_SKIPPED"
     fi
   fi
 
   if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" ]]; then
-    if [[ "${#BATS_ERROR_STACK_TRACE[@]}" -eq 0 ]]; then
+    if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       # For some versions of bash, `$?` may not be set properly for some error
       # conditions before triggering the EXIT trap directly (see #72 and #81).
       # Thanks to the `BATS_TEARDOWN_COMPLETED` signal, this will pinpoint such
@@ -283,14 +292,12 @@ bats_exit_trap() {
       # If instead the test fails, and the `teardown()` error happens while
       # `bats_teardown_trap` runs as the EXIT trap, the test will fail with no
       # output, since there's no way to reach the `bats_exit_trap` call.
-      BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
+      BATS_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
       BATS_ERROR_STATUS=1
     fi
     printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
-    bats_print_stack_trace "${BATS_ERROR_STACK_TRACE[@]}" >&3
-    bats_print_failed_command \
-      "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" \
-      "$BATS_ERROR_STATUS" >&3
+    bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
+    bats_print_failed_command >&3
 
     while IFS= read -r line; do
       printf '# %s\n' "$line"
@@ -306,51 +313,44 @@ bats_exit_trap() {
   fi
 
   rm -f "$BATS_OUT"
-  exit "$status"
-}
-
-bats_perform_tests() {
-  printf '1..%d\n' "$#"
-  test_number=1
-  status=0
-  for test_name in "$@"; do
-    if ! "$0" $BATS_EXTENDED_SYNTAX "$BATS_TEST_FILENAME" "$test_name" \
-      "$test_number"; then
-      status=1
-    fi
-    let test_number+=1
-  done
+  bats_cleanup_preprocessed_source
   exit "$status"
 }
 
 bats_perform_test() {
   BATS_TEST_NAME="$1"
-  if declare -F "$BATS_TEST_NAME" >/dev/null; then
-    BATS_TEST_NUMBER="$2"
-    if [[ -z "$BATS_TEST_NUMBER" ]]; then
-      printf '1..1\n'
-      BATS_TEST_NUMBER=1
-    fi
+  BATS_TEST_NUMBER="$2"
 
-    BATS_TEST_COMPLETED=""
-    BATS_TEARDOWN_COMPLETED=""
-    BATS_ERROR_STATUS=""
-    trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
-    trap "bats_error_trap" err
-    trap "bats_teardown_trap" exit
-    "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
-    BATS_TEST_COMPLETED=1
-    trap "bats_exit_trap" exit
-    bats_teardown_trap
-
-  else
+  if ! declare -F "$BATS_TEST_NAME" &>/dev/null; then
     printf "bats: unknown test name \`%s'\n" "$BATS_TEST_NAME" >&2
     exit 1
   fi
+
+  # Some versions of Bash will reset BASH_LINENO to the first line of the
+  # function when the ERR trap fires. All versions of Bash appear to reset it
+  # on an unbound variable access error. bats_debug_trap will fire both before
+  # the offending line is executed, and when the error is triggered.
+  # Consequently, we use `BATS_CURRENT_STACK_TRACE` recorded by the
+  # first call to bats_debug_trap, _before_ the ERR trap or unbound variable
+  # access fires.
+  BATS_STACK_TRACE=()
+  BATS_CURRENT_STACK_TRACE=()
+
+  BATS_TEST_COMPLETED=
+  BATS_TEST_SKIPPED=
+  BATS_TEARDOWN_COMPLETED=
+  BATS_ERROR_STATUS=
+  trap 'bats_debug_trap "$BASH_SOURCE"' DEBUG
+  trap 'bats_error_trap' ERR
+  trap 'bats_teardown_trap' EXIT
+  "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
+  BATS_TEST_COMPLETED=1
+  trap 'bats_exit_trap' EXIT
+  bats_teardown_trap
 }
 
 if [[ -z "$TMPDIR" ]]; then
-  BATS_TMPDIR="/tmp"
+  BATS_TMPDIR='/tmp'
 else
   BATS_TMPDIR="${TMPDIR%/}"
 fi
@@ -361,61 +361,27 @@ BATS_OUT="${BATS_TMPNAME}.out"
 
 bats_preprocess_source() {
   BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
-  . bats-preprocess <<< "$(< "$BATS_TEST_FILENAME")"$'\n' > "$BATS_TEST_SOURCE"
-  trap "bats_cleanup_preprocessed_source" err exit
-  trap "bats_cleanup_preprocessed_source; exit 1" int
-
-  bats_detect_duplicate_test_case_names
+  bats-preprocess "$BATS_TEST_FILENAME" >"$BATS_TEST_SOURCE"
+  trap 'bats_cleanup_preprocessed_source' ERR EXIT
+  trap 'bats_cleanup_preprocessed_source; exit 1' INT
 }
 
 bats_cleanup_preprocessed_source() {
   rm -f "$BATS_TEST_SOURCE"
 }
 
-bats_detect_duplicate_test_case_names() {
-  local test_names=()
-  local test_dupes=()
-  local line
-
-  while read -r line; do
-    if [[ ! "$line" =~ ^bats_test_function\  ]]; then
-      continue
-    fi
-    line="${line%$'\r'}"
-    line="${line#* }"
-
-    if [[ " ${test_names[*]} " == *" $line "* ]]; then
-      test_dupes+=("$line")
-      continue
-    fi
-    test_names+=("$line")
-  done <"$BATS_TEST_SOURCE"
-
-  if [[ "${#test_dupes[@]}" -ne 0 ]]; then
-    printf 'bats warning: duplicate test name(s) in %s: %s\n' \
-      "$BATS_TEST_FILENAME" "${test_dupes[*]}" >&2
-  fi
-}
-
 bats_evaluate_preprocessed_source() {
   if [[ -z "$BATS_TEST_SOURCE" ]]; then
     BATS_TEST_SOURCE="${BATS_PARENT_TMPNAME}.src"
   fi
+  # Dynamically loaded user files provided outside of Bats.
+  # shellcheck disable=SC1090
   source "$BATS_TEST_SOURCE"
 }
 
 exec 3<&1
 
-if [[ "$#" -eq 0 ]]; then
-  bats_preprocess_source
-  bats_evaluate_preprocessed_source
-
-  if [[ -n "$BATS_COUNT_ONLY" ]]; then
-    printf '%d\n' "${#BATS_TEST_NAMES[@]}"
-  else
-    bats_perform_tests "${BATS_TEST_NAMES[@]}"
-  fi
-else
-  bats_evaluate_preprocessed_source
-  bats_perform_test "$@"
-fi
+# Run the given test.
+bats_preprocess_source
+bats_evaluate_preprocessed_source
+bats_perform_test "$@"

--- a/vendor/bats-core/libexec/bats-core/bats-format-tap-stream
+++ b/vendor/bats-core/libexec/bats-core/bats-format-tap-stream
@@ -1,30 +1,26 @@
 #!/usr/bin/env bash
 set -e
 
-# Just stream the TAP output (sans extended syntax) if tput is missing
-if ! command -v tput >/dev/null; then
-  exec grep -v "^begin "
-fi
-
 header_pattern='[0-9]+\.\.[0-9]+'
 IFS= read -r header
 
 if [[ "$header" =~ $header_pattern ]]; then
   count="${header:3}"
   index=0
+  passed=0
   failures=0
   skipped=0
-  name=""
+  name=
   count_column_width=$(( ${#count} * 2 + 2 ))
 else
   # If the first line isn't a TAP plan, print it and pass the rest through
-  printf "%s\n" "$header"
+  printf '%s\n' "$header"
   exec cat
 fi
 
 update_screen_width() {
   screen_width="$(tput cols)"
-  count_column_left=$(( $screen_width - $count_column_width ))
+  count_column_left=$(( screen_width - count_column_width ))
 }
 
 trap update_screen_width WINCH
@@ -32,16 +28,16 @@ update_screen_width
 
 begin() {
   go_to_column 0
-  printf_with_truncation $(( $count_column_left - 1 )) "   %s" "$name"
+  buffer_with_truncation $(( count_column_left - 1 )) '   %s' "$name"
   clear_to_end_of_line
   go_to_column $count_column_left
-  printf "%${#count}s/${count}" "$index"
+  buffer "%${#count}s/${count}" "$index"
   go_to_column 1
 }
 
 pass() {
   go_to_column 0
-  printf " ✓ %s" "$name"
+  buffer ' ✓ %s' "$name"
   advance
 }
 
@@ -51,67 +47,73 @@ skip() {
     reason=": $reason"
   fi
   go_to_column 0
-  printf " - %s (skipped%s)" "$name" "$reason"
+  buffer ' - %s (skipped%s)' "$name" "$reason"
   advance
 }
 
 fail() {
   go_to_column 0
   set_color 1 bold
-  printf " ✗ %s" "$name"
+  buffer ' ✗ %s' "$name"
   advance
 }
 
 log() {
   set_color 1
-  printf "   %s\n" "$1"
+  buffer '   %s\n' "$1"
   clear_color
 }
 
 summary() {
-  printf "\n%d test" "$count"
+  buffer '\n%d test' "$count"
   if [[ "$count" -ne 1 ]]; then
-    printf 's'
+    buffer 's'
   fi
 
-  printf ", %d failure" "$failures"
+  buffer ', %d failure' "$failures"
   if [[ "$failures" -ne 1 ]]; then
-    printf 's'
+    buffer 's'
   fi
 
   if [[ "$skipped" -gt 0 ]]; then
-    printf ", %d skipped" "$skipped"
+    buffer ', %d skipped' "$skipped"
   fi
 
-  printf "\n"
+  not_run=$((count - passed - failures - skipped))
+  if [[ "$not_run" -gt 0 ]]; then
+    buffer ', %d not run' "$not_run"
+  fi
+
+  buffer '\n'
 }
 
-printf_with_truncation() {
+buffer_with_truncation() {
   local width="$1"
   shift
   local string
 
+  # shellcheck disable=SC2059
   printf -v 'string' -- "$@"
 
   if [[ "${#string}" -gt "$width" ]]; then
-    printf "%s..." "${string:0:$(( $width - 4 ))}"
+    buffer '%s...' "${string:0:$(( width - 4 ))}"
   else
-    printf "%s" "$string"
+    buffer '%s' "$string"
   fi
 }
 
 go_to_column() {
   local column="$1"
-  printf "\x1B[%dG" $(( $column + 1 ))
+  buffer '\x1B[%dG' $(( column + 1 ))
 }
 
 clear_to_end_of_line() {
-  printf "\x1B[K"
+  buffer '\x1B[K'
 }
 
 advance() {
   clear_to_end_of_line
-  printf '\n'
+  buffer '\n'
   clear_color
 }
 
@@ -122,56 +124,60 @@ set_color() {
   if [[ "$2" == 'bold' ]]; then
     weight=1
   fi
-  printf "\x1B[%d;%dm" $(( 30 + $color )) "$weight"
+  buffer '\x1B[%d;%dm' "$(( 30 + color ))" "$weight"
 }
 
 clear_color() {
-  printf "\x1B[0m"
+  buffer '\x1B[0m'
 }
 
-_buffer=""
+_buffer=
 
 buffer() {
-  _buffer="${_buffer}$("$@")"
+  local content
+  # shellcheck disable=SC2059
+  printf -v content -- "$@"
+  _buffer+="$content"
 }
 
 flush() {
-  printf "%s" "$_buffer"
-  _buffer=""
+  printf '%s' "$_buffer"
+  _buffer=
 }
 
 finish() {
   flush
-  printf "\n"
+  printf '\n'
 }
 
 trap finish EXIT
 
 while IFS= read -r line; do
   case "$line" in
-  "begin "* )
-    let index+=1
+  'begin '* )
+    ((++index))
     name="${line#* $index }"
-    buffer begin
+    begin
     flush
     ;;
-  "ok "* )
+  'ok '* )
     skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
-      let skipped+=1
-      buffer skip "${BASH_REMATCH[2]}"
+      ((++skipped))
+      skip "${BASH_REMATCH[2]}"
     else
-      buffer pass
+      ((++passed))
+      pass
     fi
     ;;
-  "not ok "* )
-    let failures+=1
-    buffer fail
+  'not ok '* )
+    ((++failures))
+    fail
     ;;
-  "# "* )
-    buffer log "${line:2}"
+  '# '* )
+    log "${line:2}"
     ;;
   esac
 done
 
-buffer summary
+summary

--- a/vendor/bats-core/libexec/bats-core/bats-preprocess
+++ b/vendor/bats-core/libexec/bats-core/bats-preprocess
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-encode_name() {
+bats_encode_test_name() {
   local name="$1"
-  local result="test_"
+  local result='test_'
   local hex_code
 
   if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
@@ -17,12 +17,12 @@ encode_name() {
 
     for ((i=0; i<length; i++)); do
       char="${name:$i:1}"
-      if [[ "$char" = " " ]]; then
-        result+="_"
+      if [[ "$char" == ' ' ]]; then
+        result+='_'
       elif [[ "$char" =~ [[:alnum:]] ]]; then
         result+="$char"
       else
-        printf -v 'hex_code' -- "-%02x" \'"$char"
+        printf -v 'hex_code' -- '-%02x' \'"$char"
         result+="$hex_code"
       fi
     done
@@ -31,24 +31,27 @@ encode_name() {
   printf -v "$2" '%s' "$result"
 }
 
+test_file="$1"
 tests=()
-index=0
 
-while IFS= read -r line; do
-  line="${line//$'\r'}"
-  let index+=1
-  if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
-    name="${BASH_REMATCH[1]#[\'\"]}"
-    name="${name%[\'\"]}"
-    body="${BASH_REMATCH[2]}"
-    encode_name "$name" 'encoded_name'
-    tests["${#tests[@]}"]="$encoded_name"
-    printf '%s() { bats_test_begin "%s" %d; %s\n' "$encoded_name" "$name" \
-      "$index" "$body"
-  else
-    printf "%s\n" "$line"
-  fi
-done
+{
+  while IFS= read -r line; do
+    line="${line//$'\r'}"
+    if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
+      name="${BASH_REMATCH[1]#[\'\"]}"
+      name="${name%[\'\"]}"
+      body="${BASH_REMATCH[2]}"
+      bats_encode_test_name "$name" 'encoded_name'
+      printf '%s() { bats_test_begin "%s"; %s\n' "${encoded_name:?}" "$name" "$body" || :
+
+      if [[ -z "$BATS_TEST_FILTER" || "$name" =~ $BATS_TEST_FILTER ]]; then
+        tests+=("$encoded_name")
+      fi
+    else
+      printf '%s\n' "$line"
+    fi
+  done
+} <<< "$(< "$test_file")"$'\n'
 
 for test_name in "${tests[@]}"; do
   printf 'bats_test_function %s\n' "$test_name"

--- a/vendor/bats-core/man/Makefile
+++ b/vendor/bats-core/man/Makefile
@@ -1,10 +1,23 @@
-RONN := ronn
+# Makefile
+#
+# bats-core manpages
+#
+RONN := ronn -W
 PAGES := bats.1 bats.7
+ORG := bats-core
+MANUAL := 'Bash Automated Testing System'
+ISOFMT := $(shell date -I)
+RM := rm -f
+
+.PHONY: all clean
 
 all: $(PAGES)
 
 bats.1: bats.1.ronn
-	$(RONN) -r $<
+	$(RONN) --date=$(ISOFMT) --manual=$(MANUAL) --organization=$(ORG) --roff $<
 
 bats.7: bats.7.ronn
-	$(RONN) -r $<
+	$(RONN) --date=$(ISOFMT) --manual=$(MANUAL) --organization=$(ORG) --roff $<
+
+clean:
+	$(RM) $(PAGES)

--- a/vendor/bats-core/man/bats.1
+++ b/vendor/bats-core/man/bats.1
@@ -1,16 +1,19 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "1" "August 2014" "" ""
+.TH "BATS" "1" "May 2019" "bats-core" "Bash Automated Testing System"
 .
 .SH "NAME"
 \fBbats\fR \- Bash Automated Testing System
 .
 .SH "SYNOPSIS"
-bats [\-c] [\-p | \-t] \fItest\fR [\fItest\fR \.\.\.]
+bats [\-cr] [\-f \fIregex\fR] [\-p | \-t] \fItest\fR\.\.\.
+.
+.br
+bats [\-h | \-v]
 .
 .P
-\fItest\fR is the path to a Bats test file, or the path to a directory containing Bats test files\.
+\fItest\fR is the path to a Bats test file, or the path to a directory containing Bats test files (ending with "\.bats")\.
 .
 .SH "DESCRIPTION"
 Bats is a TAP\-compliant testing framework for Bash\. It provides a simple way to verify that the UNIX programs you write behave as expected\.
@@ -35,6 +38,10 @@ You can invoke the \fBbats\fR interpreter with multiple test file arguments, or 
 .TP
 \fB\-c\fR, \fB\-\-count\fR
 Count the number of test cases without running any tests
+.
+.TP
+\fB\-f\fR, \fB\-\-filter\fR
+Filter test cases by names matching the regular expression
 .
 .TP
 \fB\-h\fR, \fB\-\-help\fR
@@ -99,9 +106,10 @@ Bats wiki: \fIhttps://github\.com/bats\-core/bats\-core/wiki/\fR
 \fBbash\fR(1), \fBbats\fR(7)
 .
 .SH "COPYRIGHT"
-
-(c) 2017 Bianca Tamayo (bats-core organization)
-(c) 2014 Sam Stephenson
+(c) 2017\-2018 bats\-core organization
+.
+.br
+(c) 2011\-2016 Sam Stephenson
 .
 .P
 Bats is released under the terms of an MIT\-style license\.

--- a/vendor/bats-core/man/bats.1.ronn
+++ b/vendor/bats-core/man/bats.1.ronn
@@ -5,10 +5,11 @@ bats(1) -- Bash Automated Testing System
 SYNOPSIS
 --------
 
-bats [-c] [-p | -t] <test> [<test> ...]
+bats [-cr] [-f <regex>] [-p | -t] <test>...<br/>
+bats [-h | -v]
 
-<test> is the path to a Bats test file, or the path to a directory
-containing Bats test files.
+<test> is the path to a Bats test file, or the path to a directory containing
+Bats test files (ending with ".bats").
 
 
 DESCRIPTION
@@ -48,6 +49,8 @@ OPTIONS
 
   * `-c`, `--count`:
     Count the number of test cases without running any tests
+  * `-f`, `--filter`:
+    Filter test cases by names matching the regular expression
   * `-h`, `--help`:
     Display help message
   * `-p`, `--pretty`:
@@ -103,8 +106,8 @@ Bats wiki: _https://github.com/bats\-core/bats\-core/wiki/_
 COPYRIGHT
 ---------
 
-(c) 2017 Bianca Tamayo (bats-core organization)
-(c) 2014 Sam Stephenson
+(c) 2017-2018 bats-core organization<br/>
+(c) 2011-2016 Sam Stephenson
 
 Bats is released under the terms of an MIT-style license.
 

--- a/vendor/bats-core/man/bats.7
+++ b/vendor/bats-core/man/bats.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "7" "November 2013" "" ""
+.TH "BATS" "7" "May 2019" "bats-core" "Bash Automated Testing System"
 .
 .SH "NAME"
 \fBbats\fR \- Bats test file format

--- a/vendor/bats-core/package.json
+++ b/vendor/bats-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bats",
-  "version": "1.1.0",
+  "version": "1.2.0-dev",
   "description": "Bash Automated Testing System",
   "homepage": "https://github.com/bats-core/bats-core#readme",
   "license": "MIT",

--- a/vendor/bats-core/shellcheck.sh
+++ b/vendor/bats-core/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+targets=()
+while IFS=  read -r -d $'\0'; do
+    targets+=("$REPLY")
+done < <(
+  find \
+    bin/bats \
+    libexec/bats-core \
+    shellcheck.sh \
+    -type f \
+    -print0
+  )
+
+for file in "${targets[@]}"; do
+  [ -f "${file}" ] && LC_ALL=C.UTF-8 shellcheck "${file}"
+done;

--- a/vendor/bats-core/test/bats.bats
+++ b/vendor/bats-core/test/bats.bats
@@ -7,15 +7,14 @@ fixtures bats
   run bats
   [ $status -eq 1 ]
   [ "${lines[0]}" == 'Error: Must specify at least one <test>' ]
-  [ "${lines[2]%% *}" == 'Usage:' ]
+  [ "${lines[1]%% *}" == 'Usage:' ]
 }
 
 @test "invalid option prints message and usage instructions" {
   run bats --invalid-option
   [ $status -eq 1 ]
-  emit_debug_output
-  [ "${lines[0]}" == "Error: Bad command line option '-invalid-option'" ]
-  [ "${lines[2]%% *}" == 'Usage:' ]
+  [ "${lines[0]}" == "Error: Bad command line option '--invalid-option'" ]
+  [ "${lines[1]%% *}" == 'Usage:' ]
 }
 
 @test "-v and --version print version number" {
@@ -264,7 +263,8 @@ fixtures bats
 }
 
 @test "extended syntax" {
-  run bats-exec-test -x "$FIXTURE_ROOT/failing_and_passing.bats"
+  emulate_bats_env
+  run bats-exec-suite -x "$FIXTURE_ROOT/failing_and_passing.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'begin 1 a failing test' ]
   [ "${lines[2]}" = 'not ok 1 a failing test' ]
@@ -285,10 +285,10 @@ fixtures bats
 }
 
 @test "pretty formatter bails on invalid tap" {
-  run bats --tap "$FIXTURE_ROOT/invalid_tap.bats"
-  [ $status -eq 1 ]
-  [ "${lines[0]}" = "This isn't TAP!" ]
-  [ "${lines[1]}" = "Good day to you" ]
+  run bats-format-tap-stream < <(printf "This isn't TAP.\nGood day to you.\n")
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "This isn't TAP." ]
+  [ "${lines[1]}" = "Good day to you." ]
 }
 
 @test "single-line tests" {
@@ -466,4 +466,72 @@ END_OF_ERR_MSG
   [ "${lines[4]}" = '# foo' ]
   [ "${lines[5]}" = '# bar' ]
   [ "${lines[6]}" = '# baz' ]
+}
+
+@test "parallel test execution with --jobs" {
+  type -p parallel &>/dev/null || skip "--jobs requires GNU parallel"
+
+  SECONDS=0
+  run bats --jobs 10 "$FIXTURE_ROOT/parallel.bats"
+  duration="$SECONDS"
+  [ "$status" -eq 0 ]
+  # Make sure the lines are in-order.
+  [[ "${lines[0]}" == "1..10" ]]
+  for t in {1..10}; do
+    [[ "${lines[$t]}" == "ok $t slow test $t" ]]
+  done
+  # In theory it should take 3s, but let's give it bit of extra time instead.
+  [[ "$duration" -lt 20 ]]
+}
+
+@test "run tests which consume stdin (see #197)" {
+  run bats "$FIXTURE_ROOT/read_from_stdin.bats"
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" == "1..3" ]]
+  [[ "${lines[1]}" == "ok 1 test 1" ]]
+  [[ "${lines[2]}" == "ok 2 test 2 with	TAB in name" ]]
+  [[ "${lines[3]}" == "ok 3 test 3" ]]
+}
+
+@test "report correct line on unset variables" {
+  run bats "$FIXTURE_ROOT/unbound_variable.bats"
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 9 ]
+  [ "${lines[1]}" = 'not ok 1 access unbound variable' ]
+  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/unbound_variable.bats, line 8)" ]
+  [ "${lines[3]}" = "#   \`foo=\$unset_variable' failed" ]
+  [[ "${lines[4]}" =~ ".src: line 8:" ]]
+  [ "${lines[5]}" = 'not ok 2 access second unbound variable' ]
+  [ "${lines[6]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/unbound_variable.bats, line 13)" ]
+  [ "${lines[7]}" = "#   \`foo=\$second_unset_variable' failed" ]
+  [[ "${lines[8]}" =~ ".src: line 13:" ]]
+}
+
+@test "report correct line on external function calls" {
+  run bats "$FIXTURE_ROOT/external_function_calls.bats"
+  [ "$status" -eq 1 ]
+
+  expectedNumberOfTests=12
+  linesOfOutputPerTest=3
+  [ "${#lines[@]}" -gt $((expectedNumberOfTests * linesOfOutputPerTest + 1)) ]
+
+  outputOffset=1
+  currentErrorLine=9
+  linesPerTest=5
+
+  for t in $(seq $expectedNumberOfTests); do
+    [[ "${lines[$outputOffset]}" =~ "not ok $t " ]]
+    # Skip backtrace into external function if set
+    if [[ "${lines[$((outputOffset + 1))]}" =~ "# (from function " ]]; then
+      outputOffset=$((outputOffset + 1))
+      parenChar=" "
+    else
+      parenChar="("
+    fi
+
+    [ "${lines[$((outputOffset + 1))]}" = "# ${parenChar}in test file $RELATIVE_FIXTURE_ROOT/external_function_calls.bats, line $currentErrorLine)" ]
+    [[ "${lines[$((outputOffset + 2))]}" =~ " failed" ]]
+    outputOffset=$((outputOffset + 3))
+    currentErrorLine=$((currentErrorLine + linesPerTest))
+  done
 }

--- a/vendor/bats-core/test/fixtures/bats/cmd_using_stdin.bash
+++ b/vendor/bats-core/test/fixtures/bats/cmd_using_stdin.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Fractional timeout supported in bash 4+
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    timeout=1
+else
+    timeout=0.01
+fi
+
+# Just reading from stdin
+while read -r -t $timeout foo; do
+    if [ "$foo" == "EXIT" ]; then
+        echo "Found"
+        exit 0
+    fi
+done
+
+echo "Not found"
+exit 1

--- a/vendor/bats-core/test/fixtures/bats/external_function_calls.bats
+++ b/vendor/bats-core/test/fixtures/bats/external_function_calls.bats
@@ -1,0 +1,65 @@
+load test_helper
+
+# Test various combinations that may fail line number detection in stack trace
+# Tests are designed so the first statement succeeds and 2nd fails
+# All tests fail on the same line so checking can be automated
+
+@test "Call true function && false" {
+    help_me
+    help_me && false
+}
+
+@test "Call true function && return 1" {
+    help_me
+    help_me && return 1
+}
+
+@test "Call true function and invert" {
+    help_me
+    ! help_me
+}
+
+@test "Call false function || false" {
+    ! failing_helper
+    failing_helper || false
+}
+
+@test "Call false function && return 1" {
+    ! failing_helper
+    failing_helper || return 1
+}
+
+@test "Call false function" {
+    ! failing_helper
+    failing_helper
+}
+
+@test "Call return_0 function && false" {
+    return_0
+    return_0 && false
+}
+
+@test "Call return_0 function && return 1" {
+    return_0
+    return_0 && return 1
+}
+
+@test "Call return_0 function and invert" {
+    return_0
+    ! return_0
+}
+
+@test "Call return_1 function || false" {
+    ! return_1
+    return_1 || false
+}
+
+@test "Call return_1 function && return 1" {
+    ! return_1
+    return_1 || return 1
+}
+
+@test "Call return_1 function" {
+    ! return_1
+    return_1
+}

--- a/vendor/bats-core/test/fixtures/bats/invalid_tap.bats
+++ b/vendor/bats-core/test/fixtures/bats/invalid_tap.bats
@@ -1,7 +1,0 @@
-echo "This isn't TAP!"
-echo "Good day to you"
-exit 1
-
-@test "truth" {
-  true
-}

--- a/vendor/bats-core/test/fixtures/bats/parallel.bats
+++ b/vendor/bats-core/test/fixtures/bats/parallel.bats
@@ -1,0 +1,39 @@
+@test "slow test 1" {
+  sleep 3s
+}
+
+@test "slow test 2" {
+  sleep 3s
+}
+
+@test "slow test 3" {
+  sleep 3s
+}
+
+@test "slow test 4" {
+  sleep 3s
+}
+
+@test "slow test 5" {
+  sleep 3s
+}
+
+@test "slow test 6" {
+  sleep 3s
+}
+
+@test "slow test 7" {
+  sleep 3s
+}
+
+@test "slow test 8" {
+  sleep 3s
+}
+
+@test "slow test 9" {
+  sleep 3s
+}
+
+@test "slow test 10" {
+  sleep 3s
+}

--- a/vendor/bats-core/test/fixtures/bats/read_from_stdin.bats
+++ b/vendor/bats-core/test/fixtures/bats/read_from_stdin.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+@test "test 1" {
+    # Don't print anything
+    run bash -c "$BATS_TEST_DIRNAME/cmd_using_stdin.bash"
+    [ "$status" -eq 1 ]
+    [ "$output" = "Not found" ]
+}
+
+@test "test 2 with	TAB in name" {
+    run bash -c "echo EXIT | $BATS_TEST_DIRNAME/cmd_using_stdin.bash"
+    [ "$status" -eq 0 ]
+    [ "$output" = "Found" ]
+}
+
+@test "test 3" {
+    run bash -c "echo EXIT | $BATS_TEST_DIRNAME/cmd_using_stdin.bash"
+    [ "$status" -eq 0 ]
+    [ "$output" = "Found" ]
+}

--- a/vendor/bats-core/test/fixtures/bats/test_helper.bash
+++ b/vendor/bats-core/test/fixtures/bats/test_helper.bash
@@ -5,3 +5,15 @@ help_me() {
 failing_helper() {
   false
 }
+
+return_0() {
+  # Just return 0. Intentional assignment to boost line numbers
+  result=0
+  return $result
+}
+
+return_1() {
+  # Just return 0. Intentional assignment to boost line numbers
+  result=1
+  return $result
+}

--- a/vendor/bats-core/test/fixtures/bats/unbound_variable.bats
+++ b/vendor/bats-core/test/fixtures/bats/unbound_variable.bats
@@ -1,0 +1,14 @@
+set -u
+
+# This file is used to test line number offsets. Any changes to lines will affect tests
+
+@test "access unbound variable" {
+    unset unset_variable
+    # Add a line for checking line number
+    foo=$unset_variable
+}
+
+@test "access second unbound variable" {
+    unset second_unset_variable
+    foo=$second_unset_variable
+}

--- a/vendor/bats-core/test/fixtures/suite/filter/a.bats
+++ b/vendor/bats-core/test/fixtures/suite/filter/a.bats
@@ -1,0 +1,3 @@
+@test 'foo in a' { }
+@test '--bar in a' { }
+@test 'baz in a' { }

--- a/vendor/bats-core/test/fixtures/suite/filter/b.bats
+++ b/vendor/bats-core/test/fixtures/suite/filter/b.bats
@@ -1,0 +1,3 @@
+@test 'bar_in_b' { }
+@test '--baz_in_b' { }
+@test 'quux_in_b' { }

--- a/vendor/bats-core/test/fixtures/suite/filter/c.bats
+++ b/vendor/bats-core/test/fixtures/suite/filter/c.bats
@@ -1,0 +1,3 @@
+@test 'quux_in c' { }
+@test 'xyzzy in c' { }
+@test 'plugh_in c' { }

--- a/vendor/bats-core/test/fixtures/suite/parallel/parallel1.bats
+++ b/vendor/bats-core/test/fixtures/suite/parallel/parallel1.bats
@@ -1,0 +1,39 @@
+@test "slow test 1" {
+  sleep 3s
+}
+
+@test "slow test 2" {
+  sleep 3s
+}
+
+@test "slow test 3" {
+  sleep 3s
+}
+
+@test "slow test 4" {
+  sleep 3s
+}
+
+@test "slow test 5" {
+  sleep 3s
+}
+
+@test "slow test 6" {
+  sleep 3s
+}
+
+@test "slow test 7" {
+  sleep 3s
+}
+
+@test "slow test 8" {
+  sleep 3s
+}
+
+@test "slow test 9" {
+  sleep 3s
+}
+
+@test "slow test 10" {
+  sleep 3s
+}

--- a/vendor/bats-core/test/fixtures/suite/parallel/parallel2.bats
+++ b/vendor/bats-core/test/fixtures/suite/parallel/parallel2.bats
@@ -1,0 +1,39 @@
+@test "slow test 1" {
+  sleep 3s
+}
+
+@test "slow test 2" {
+  sleep 3s
+}
+
+@test "slow test 3" {
+  sleep 3s
+}
+
+@test "slow test 4" {
+  sleep 3s
+}
+
+@test "slow test 5" {
+  sleep 3s
+}
+
+@test "slow test 6" {
+  sleep 3s
+}
+
+@test "slow test 7" {
+  sleep 3s
+}
+
+@test "slow test 8" {
+  sleep 3s
+}
+
+@test "slow test 9" {
+  sleep 3s
+}
+
+@test "slow test 10" {
+  sleep 3s
+}

--- a/vendor/bats-core/test/fixtures/suite/parallel/parallel3.bats
+++ b/vendor/bats-core/test/fixtures/suite/parallel/parallel3.bats
@@ -1,0 +1,39 @@
+@test "slow test 1" {
+  sleep 3s
+}
+
+@test "slow test 2" {
+  sleep 3s
+}
+
+@test "slow test 3" {
+  sleep 3s
+}
+
+@test "slow test 4" {
+  sleep 3s
+}
+
+@test "slow test 5" {
+  sleep 3s
+}
+
+@test "slow test 6" {
+  sleep 3s
+}
+
+@test "slow test 7" {
+  sleep 3s
+}
+
+@test "slow test 8" {
+  sleep 3s
+}
+
+@test "slow test 9" {
+  sleep 3s
+}
+
+@test "slow test 10" {
+  sleep 3s
+}

--- a/vendor/bats-core/test/fixtures/suite/parallel/parallel4.bats
+++ b/vendor/bats-core/test/fixtures/suite/parallel/parallel4.bats
@@ -1,0 +1,39 @@
+@test "slow test 1" {
+  sleep 3s
+}
+
+@test "slow test 2" {
+  sleep 3s
+}
+
+@test "slow test 3" {
+  sleep 3s
+}
+
+@test "slow test 4" {
+  sleep 3s
+}
+
+@test "slow test 5" {
+  sleep 3s
+}
+
+@test "slow test 6" {
+  sleep 3s
+}
+
+@test "slow test 7" {
+  sleep 3s
+}
+
+@test "slow test 8" {
+  sleep 3s
+}
+
+@test "slow test 9" {
+  sleep 3s
+}
+
+@test "slow test 10" {
+  sleep 3s
+}

--- a/vendor/bats-core/test/install.bats
+++ b/vendor/bats-core/test/install.bats
@@ -13,7 +13,6 @@ setup() {
 
 @test "install.sh creates a valid installation" {
   run "$BATS_ROOT/install.sh" "$INSTALL_DIR"
-  emit_debug_output
   [ "$status" -eq 0 ]
   [ "$output" == "Installed Bats to $INSTALL_DIR/bin/bats" ]
   [ -x "$INSTALL_DIR/bin/bats" ]

--- a/vendor/bats-core/test/suite.bats
+++ b/vendor/bats-core/test/suite.bats
@@ -52,6 +52,7 @@ fixtures suite
 }
 
 @test "extended syntax in suite" {
+  emulate_bats_env
   FLUNK=1 run bats-exec-suite -x "$FIXTURE_ROOT/multiple/"*.bats
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
@@ -77,4 +78,71 @@ fixtures suite
   [ "${lines[0]}" = "1..2" ]
   [ "${lines[1]}" = "ok 1 another passing test" ]
   [ "${lines[2]}" = "ok 2 a passing test" ]
+}
+
+@test "run entire suite when --filter isn't set" {
+  run bats "${FIXTURE_ROOT}/filter"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = '1..9' ]
+  [ "${lines[1]}" = 'ok 1 foo in a' ]
+  [ "${lines[2]}" = 'ok 2 --bar in a' ]
+  [ "${lines[3]}" = 'ok 3 baz in a' ]
+  [ "${lines[4]}" = 'ok 4 bar_in_b' ]
+  [ "${lines[5]}" = 'ok 5 --baz_in_b' ]
+  [ "${lines[6]}" = 'ok 6 quux_in_b' ]
+  [ "${lines[7]}" = 'ok 7 quux_in c' ]
+  [ "${lines[8]}" = 'ok 8 xyzzy in c' ]
+  [ "${lines[9]}" = 'ok 9 plugh_in c' ]
+}
+
+@test "use --filter to run subset of test cases from across the suite" {
+  run bats -f 'ba[rz]' "${FIXTURE_ROOT}/filter"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = '1..4' ]
+  [ "${lines[1]}" = 'ok 1 --bar in a' ]
+  [ "${lines[2]}" = 'ok 2 baz in a' ]
+  [ "${lines[3]}" = 'ok 3 bar_in_b' ]
+  [ "${lines[4]}" = 'ok 4 --baz_in_b' ]
+
+  local prev_output="$output"
+
+  run bats --filter 'ba[rz]' "${FIXTURE_ROOT}/filter"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$prev_output" ]
+}
+
+@test "--filter can handle regular expressions that contain [_- ]" {
+  run bats -f '--ba[rz][ _]in' "${FIXTURE_ROOT}/filter"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = '1..2' ]
+  [ "${lines[1]}" = 'ok 1 --bar in a' ]
+  [ "${lines[2]}" = 'ok 2 --baz_in_b' ]
+}
+
+@test "--filter can handle regular expressions that start with ^" {
+  run bats -f '^ba[rz]' "${FIXTURE_ROOT}/filter"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = '1..2' ]
+  [ "${lines[1]}" = 'ok 1 baz in a' ]
+  [ "${lines[2]}" = 'ok 2 bar_in_b' ]
+}
+
+@test "parallel suite execution with --jobs" {
+  type -p parallel &>/dev/null || skip "--jobs requires GNU parallel"
+
+  SECONDS=0
+  run bats --jobs 40 "$FIXTURE_ROOT/parallel"
+  duration="$SECONDS"
+  [ "$status" -eq 0 ]
+  # Make sure the lines are in-order.
+  [[ "${lines[0]}" == "1..40" ]]
+  i=0
+  for s in {1..4}; do
+    for t in {1..10}; do
+      ((++i))
+      [[ "${lines[$i]}" == "ok $i slow test $t" ]]
+    done
+  done
+  # In theory it should take 3s, but let's give it bit of extra time instead.
+  [[ "$duration" -lt 20 ]]
 }

--- a/vendor/bats-core/test/test_helper.bash
+++ b/vendor/bats-core/test/test_helper.bash
@@ -1,6 +1,12 @@
+emulate_bats_env() {
+  export BATS_CWD="$PWD"
+  export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
+  export BATS_TEST_FILTER=
+}
+
 fixtures() {
   FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures/$1"
-  bats_trim_filename "$FIXTURE_ROOT" 'RELATIVE_FIXTURE_ROOT'
+  RELATIVE_FIXTURE_ROOT="${FIXTURE_ROOT#$BATS_CWD/}"
 }
 
 make_bats_test_suite_tmpdir() {


### PR DESCRIPTION
Update bats-core to https://github.com/bats-core/bats-core/commit/e582ef5aa6303285000edb5ef8651e6235705382

This lets us use bats-core's new `[-f <regex>]` option to run a subset of tests, which will run more quickly than the full battery of tests.