### PR TITLE
Allow passing files to be encrypted to git-secret hide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## {Next Version}
+### Features
+- Allow passing paths of files to encrypt to git-secret hide
 
 ### Misc
 

--- a/man/man1/git-secret-hide.1.ronn
+++ b/man/man1/git-secret-hide.1.ronn
@@ -8,7 +8,8 @@ git-secret-hide - encrypts all added files with the inner keyring.
 
 ## DESCRIPTION
 `git-secret-hide` creates an encrypted version (typically called `filename.txt.secret`) 
-of each file added by `git-secret-add` command. 
+of each file added by `git-secret-add` command 
+or the passed `pathspec`s. 
 Now anyone enabled via 'git secret tell' can can decrypt these files. Under the hood,
 `git-secret` uses the keyring in `.gitsecret/keys` and user's secret keys to decrypt the files.
 

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -131,7 +131,7 @@ function hide {
       has_record=$(_fsdb_has_record "$path" "$fsdb")
 
       if [ "$has_record" -eq 1 ]; then
-        _abort "file not exits in git secret database: $path" 1
+        _abort "file does not exist in git secret database: $path" 1
       fi
 
       record=$(_fsdb_get_record "$path" "$fsdb")

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -108,10 +108,6 @@ function hide {
   shift $((OPTIND-1))
   [ "$1" = '--' ] && shift
 
-  if [ $# -ne 0 ]; then 
-    _abort "hide does not understand params: $*"
-  fi
-
   # We need user to continue:
   _user_required
 
@@ -128,9 +124,13 @@ function hide {
 
   # make sure all the unencrypted files needed are present
   local to_hide=()
-  while read -r record; do
-    to_hide+=("$record")  # add record to array
-  done < "$path_mappings"
+  if [ $# -ne 0 ]; then 
+    to_hide=( "$@" )
+  else
+    while read -r record; do
+      to_hide+=("$record")  # add record to array
+    done < "$path_mappings"
+  fi
 
   local recipients
   recipients=$(_get_recipients)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--------------------------------------------------
Allows for passing the names of the files you want to encrypt to `git-secret hide`.
It is possible to reveal specific secrets by passing the relevant file to `reveal`. But when you edit that revealed file and want to encrypt it again you will be presented with errors that the files being encrypted cannot be found. This is because `hide` tries to encrypt all files listed in the fsdb. Even when you have revealed only one file. To circumvent this you can pass the `-F` flag to `hide`. But you will still get a lot of warnings. This pull request aims to solve this problem by allowing you to specify which files you want `hide` to encrypt. `hide` will check if the specified file exists in the database and will abort if it does not.
