### PR TITLE
Arch docs improve

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -53,9 +53,13 @@ sudo mv bintray-sobolevn-rpm.repo /etc/yum.repos.d/
 sudo yum install git-secret
 ```
 
-### Arch
+### Arch Linux
 
-You can install from the [AUR](https://aur.archlinux.org/packages/git-secret/) using your helper of choice by installing the package `git-secret` e.g. with [yay](https://github.com/Jguer/yay)
+The `Arch` way to install git-secret is to use the directions for
+"Installing Packages" at [Arch User Repository Documentation](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
+along with the PKGBUILD file from (https://aur.archlinux.org/packages/git-secret/)
+
+You can also install from the [AUR](https://aur.archlinux.org/packages/git-secret/) using your helper of choice by installing the package `git-secret` e.g. with [yay](https://github.com/Jguer/yay)
 
 ```bash
 yay -S git-secret

--- a/installation.md
+++ b/installation.md
@@ -55,7 +55,7 @@ sudo yum install git-secret
 
 ### Arch Linux
 
-The `Arch` way to install git-secret is to use the directions for
+The _Arch_ way to install git-secret is to use the directions for
 "Installing Packages" at [Arch User Repository Documentation](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
 along with the PKGBUILD file from the [git-secret Arch Linux Package](https://aur.archlinux.org/packages/git-secret/)
 

--- a/installation.md
+++ b/installation.md
@@ -57,7 +57,7 @@ sudo yum install git-secret
 
 The `Arch` way to install git-secret is to use the directions for
 "Installing Packages" at [Arch User Repository Documentation](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
-along with the PKGBUILD file from (https://aur.archlinux.org/packages/git-secret/)
+along with the PKGBUILD file from the [git-secret Arch Linux Package](https://aur.archlinux.org/packages/git-secret/)
 
 You can also install from the [AUR](https://aur.archlinux.org/packages/git-secret/) using your helper of choice by installing the package `git-secret` e.g. with [yay](https://github.com/Jguer/yay)
 

--- a/installation.md
+++ b/installation.md
@@ -57,7 +57,7 @@ sudo yum install git-secret
 
 The _Arch_ way to install git-secret is to use the directions for
 "Installing Packages" at [Arch User Repository Documentation](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
-along with the PKGBUILD file from the [git-secret Arch Linux Package](https://aur.archlinux.org/packages/git-secret/)
+along with the `PKGBUILD` file from the [git-secret Arch Linux Package](https://aur.archlinux.org/packages/git-secret/)
 
 You can also install from the [AUR](https://aur.archlinux.org/) using your helper of choice by installing the package `git-secret` e.g. with [yay](https://github.com/Jguer/yay)
 

--- a/installation.md
+++ b/installation.md
@@ -59,7 +59,8 @@ The _Arch_ way to install git-secret is to use the directions for
 "Installing Packages" at [Arch User Repository Documentation](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
 along with the `PKGBUILD` file from the [git-secret Arch Linux Package](https://aur.archlinux.org/packages/git-secret/)
 
-You can also install from the [AUR](https://aur.archlinux.org/) using your helper of choice by installing the package `git-secret` e.g. with [yay](https://github.com/Jguer/yay)
+You can also install from the [AUR](https://aur.archlinux.org/) using your helper of choice by 
+installing the package `git-secret`, for example using [yay](https://github.com/Jguer/yay)
 
 ```bash
 yay -S git-secret

--- a/installation.md
+++ b/installation.md
@@ -59,7 +59,7 @@ The _Arch_ way to install git-secret is to use the directions for
 "Installing Packages" at [Arch User Repository Documentation](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
 along with the PKGBUILD file from the [git-secret Arch Linux Package](https://aur.archlinux.org/packages/git-secret/)
 
-You can also install from the [AUR](https://aur.archlinux.org/packages/git-secret/) using your helper of choice by installing the package `git-secret` e.g. with [yay](https://github.com/Jguer/yay)
+You can also install from the [AUR](https://aur.archlinux.org/) using your helper of choice by installing the package `git-secret` e.g. with [yay](https://github.com/Jguer/yay)
 
 ```bash
 yay -S git-secret


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--------------------------------------------------
Documents the "Arch Linux" recommended way to install git-secret from the Arch Linux User Repository
Expands on Arch docs added in https://github.com/sobolevn/git-secret/pull/583