### PR TITLE
More precise feedback about added files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reflect changes in ruby bundler during build process
 - Upgrade build process to ansible 2.9
 - Use shellcheck 0.7.1 with CI, not 'latest' (#609)
+- Improve output of git-secret add
 
 ## Version 0.3.2
 

--- a/man/man1/git-secret-add.1.ronn
+++ b/man/man1/git-secret-add.1.ronn
@@ -3,7 +3,7 @@ git-secret-add - starts to track added files.
 
 ## SYNOPSIS
 
-    git secret add [-i] <pathspec>...
+    git secret add [-v] [-i] <pathspec>...
 
 
 ## DESCRIPTION
@@ -23,6 +23,7 @@ folder using the SECRETS_DIR environment variable.
 
 ## OPTIONS
 
+    -v  - verbose, shows extra information.
     -i  - does nothing, adding paths to .gitignore is now the default behavior.
     -h  - shows this help.
 

--- a/src/commands/git_secret_add.sh
+++ b/src/commands/git_secret_add.sh
@@ -5,11 +5,13 @@ function add {
   local auto_ignore=1
   OPTIND=1
 
-  while getopts "ih" opt; do
+  while getopts "ihv" opt; do
     case "$opt" in
       i) auto_ignore=1;;    # this doesn't change anything
 
       h) _show_manual_for "add";;
+
+      v) _SECRETS_VERBOSE=1;;
 
       *) _invalid_option_for "add";;
     esac
@@ -82,6 +84,8 @@ function add {
 
   local fsdb
   fsdb=$(_get_secrets_dir_paths_mapping)
+  local count
+  count=0
 
   for item in "${items[@]}"; do
     local path
@@ -94,8 +98,13 @@ function add {
     already_in=$(_fsdb_has_record "$key" "$fsdb")
     if [[ "$already_in" -eq 1 ]]; then
       echo "$key" >> "$fsdb"
+       if [[ -n "$_SECRETS_VERBOSE" ]]; then
+        _message "adding file: $key"
+      fi
+      
+      ((count=count+1))
     fi
   done
 
-  _message "${#@} item(s) added."
+  _message "$count item(s) added."
 }

--- a/tests/test_add.bats
+++ b/tests/test_add.bats
@@ -237,10 +237,11 @@ function teardown {
 
   # Testing:
   run git secret add -v "$filename1" "$filename2"
-  local newline=$'\n'
-  local expected_message="git-secret: adding file: ${TEST_DEFAULT_FILENAME}${newline}git-secret: adding file: ${TEST_SECOND_FILENAME}${newline}git-secret: 2 item(s) added."
+
   [ "$status" -eq 0 ]
-  [ "$output" = "$expected_message" ]
+  [[ "$output" == *"git-secret: adding file: ${TEST_DEFAULT_FILENAME}"* ]]
+  [[ "$output" == *"git-secret: adding file: ${TEST_SECOND_FILENAME}"* ]]
+  [[ "$output" == *"git-secret: 2 item(s) added."* ]]
 
   # Cleaning up:
   rm "$filename1" "$filename2" ".gitignore"

--- a/tests/test_add.bats
+++ b/tests/test_add.bats
@@ -191,7 +191,7 @@ function teardown {
   run git secret add "$filename"
   run git secret add "$filename"
   [ "$status" -eq 0 ]
-  [ "$output" = "git-secret: 1 item(s) added." ]
+  [ "$output" = "git-secret: 0 item(s) added." ]
 
   # Ensuring that path mappings was set correctly:
   local path_mappings
@@ -217,8 +217,30 @@ function teardown {
 
   # Testing:
   run git secret add "$filename1" "$filename2"
+  local newline=$'\n'
   [ "$status" -eq 0 ]
   [ "$output" = "git-secret: 2 item(s) added." ]
+
+  # Cleaning up:
+  rm "$filename1" "$filename2" ".gitignore"
+}
+
+@test "run 'add -v' for multiple files" {
+  # Preparations:
+  local filename1="$TEST_DEFAULT_FILENAME"
+  echo "content1" > "$filename1"
+  echo "$filename1" > ".gitignore"
+
+  local filename2="$TEST_SECOND_FILENAME"
+  echo "content2" > "$filename2"
+  echo "$filename2" >> ".gitignore"
+
+  # Testing:
+  run git secret add -v "$filename1" "$filename2"
+  local newline=$'\n'
+  local expected_message="git-secret: adding file: ${TEST_DEFAULT_FILENAME}${newline}git-secret: adding file: ${TEST_SECOND_FILENAME}${newline}git-secret: 2 item(s) added."
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected_message" ]
 
   # Cleaning up:
   rm "$filename1" "$filename2" ".gitignore"


### PR DESCRIPTION
This adapts the output of the add command in order to report exactly which
files have been added. Specially with wildcard patterns, this makes it
easier to verify that expected files are added.

Any relevant logs, error output, etc?
------------------------------------- 
```bash
$ git secret add *.md
git-secret: 0 item(s) added.
$ touch test.md test2.md
$ git secret add *.md
git-secret: Adding test2.md...
git-secret: Adding test.md...
git-secret: 2 item(s) added.
```