### PR TITLE
make "usage" message easier to read

### DIFF
--- a/src/commands/git_secret_usage.sh
+++ b/src/commands/git_secret_usage.sh
@@ -15,25 +15,24 @@ function usage {
   shift $((OPTIND-1))
   [ "$1" = "--" ] && shift
 
-  # There was a bug with some shells, which were adding extra commands
-  # to the old dynamic-loading version of this code.
-  # thanks to @antmak it is now fixed, see:
-  # https://github.com/sobolevn/git-secret/issues/47
-  local commands="add|cat|changes|clean|hide|init|killperson|list|remove|reveal|tell|usage|whoknows"
-
-  echo "usage: git secret [--version] [$commands]"
-  echo " 'git secret --version' will show version and exit"
-  echo "See 'git secret [command] -h' for more info about commands and their options"
-  echo " add [filename.txt] - adds file to be hidden, optionally adds file to .gitignore"
-  echo " cat [filename.txt] - cats the decrypted contents of the named file to stdout"
-  echo " changes [filename.secret] - indicates if the file changed since last commit"
-  echo " clean - deletes encrypted files"
-  echo " hide - encrypts (or re-encrypts) the files to be hidden"
-  echo " init - creates the .gitsecret directory and contents needed for git-secret"
-  echo " killperson [emails] - the reverse of 'tell', removes access for the named user"
-  echo " list - shows files to be hidden/encrypted, as in .gitsecret/paths/mapping.cfg"
-  echo " remove [files] - removes files from list of hidden files"
-  echo " reveal - decrypts all hidden files, as mentioned in 'git secret list'"
-  echo " tell [email] - add access for the user with imported public key with email"
-  echo " whoknows - shows list of email addresses associated with public keys that can reveal files"
+  echo "usage: git secret [--version] [command] [command-options]"
+  echo ""
+  echo "options:"
+  echo " --version                 - prints the version number"
+  echo ""
+  echo "commands:"
+  echo "see 'git secret [command] -h' for more info about commands and their options"
+  echo " add [file.txt]            - adds file to be hidden to the list"
+  echo " cat [file.txt]            - decrypts and prints contents of the file"
+  echo " changes [file.txt.secret] - indicates if the file changed since last commit"
+  echo " clean                     - deletes all encrypted files"
+  echo " hide                      - encrypts (or re-encrypts) the files to be hidden"
+  echo " init                      - initializes the  git-secret repository"
+  echo " killperson [emails]       - deletes a person's public key from the keyring"
+  echo " list                      - prints all the added files"
+  echo " remove [files]            - removes files from the list of hidden files"
+  echo " reveal                    - decrypts all hidden files"
+  echo " tell [email]              - imports a person's public key into the keyring"
+  echo " usage                     - prints this message"
+  echo " whoknows                  - prints list of authorized email addresses"
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .ronn file(s) in man/man*/ to document your changes if appropriate 
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? 
---------------------------------------------------
this PR makes the output message of `git secret usage` easier to read:

Second try:
```
usage: git secret [--version] [command] [command-options]

options:
 --version                 - prints the version number

commands:
see 'git secret [command] -h' for more info about commands and their options
 add [file.txt]            - adds file to be hidden to the list
 cat [file.txt]            - decrypts and prints contents of the file
 changes [file.txt.secret] - indicates if the file changed since last commit
 clean                     - deletes all encrypted files
 hide                      - encrypts (or re-encrypts) the files to be hidden
 init                      - initializes the  git-secret repository
 killperson [emails]       - deletes a person's public key from the keyring
 list                      - prints all the added files
 remove [files]            - removes files from the list of hidden files
 reveal                    - decrypts all hidden files
 tell [email]              - imports a person's public key into the keyring
 usage                     - prints this message
 whoknows                  - prints list of authorized email addresses
```

Outdated - first try:
```
usage: git secret [--version] [add|cat|changes|clean|hide|init|killperson|list|remove|reveal|tell|usage|whoknows]

options:
 --version                 - will show version and exit

commands:
see 'git secret [command] -h' for more info about commands and their options
 add [filename.txt]        - adds file to be hidden, optionally adds file to .gitignore
 cat [filename.txt]        - cats the decrypted contents of the named file to stdout
 changes [filename.secret] - indicates if the file changed since last commit
 clean                     - deletes encrypted files
 hide                      - encrypts (or re-encrypts) the files to be hidden
 init                      - creates the .gitsecret directory and contents needed for git-secret
 killperson [emails]       - the reverse of 'tell', removes access for the named user
 list                      - shows files to be hidden/encrypted, as in .gitsecret/paths/mapping.cfg
 remove [files]            - removes files from list of hidden files
 reveal                    - decrypts all hidden files, as mentioned in 'git secret list'
 tell [email]              - add access for the user with imported public key with email
 usage                     - prints this message
 whoknows                  - shows list of email addresses associated with public keys that can reveal files
```

