### PR TITLE
add bash string escaping to _add_ignored_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Error if 'tell' is used on an email address with multiple keys (#552)
 - Don't let 'reveal' clobber secret files (#579)
 - Updated test key fixture that had expired (#607)
+- Escape filenames with special characters before adding to .gitignore
 
 ### Misc
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -335,7 +335,7 @@ function _add_ignored_file {
   local full_path
   full_path=$(_append_root_path '.gitignore')
 
-  echo "$filename" >> "$full_path"
+  printf '%q' "$filename" >> "$full_path"
 }
 
 

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -60,6 +60,7 @@ export TEST_ATTACKER_USER="attacker1@gitsecret.io"
 export TEST_DEFAULT_FILENAME="space file" # has spaces
 export TEST_SECOND_FILENAME="space file two" # has spaces
 export TEST_THIRD_FILENAME="space file three"  # has spaces
+export TEST_FOURTH_FILENAME="space file three [] * $"  # has spaces and special chars
 
 
 function test_user_password {
@@ -303,6 +304,7 @@ function unset_current_state {
   rm -vrf "${TEST_GPG_HOMEDIR:?}/${TEST_DEFAULT_FILENAME}"  2>&1 | sed 's/^/# unset_current_state: rm /'
   rm -vrf "${TEST_GPG_HOMEDIR:?}/${TEST_SECOND_FILENAME}"   2>&1 | sed 's/^/# unset_current_state: rm /'
   rm -vrf "${TEST_GPG_HOMEDIR:?}/${TEST_THIRD_FILENAME}"    2>&1 | sed 's/^/# unset_current_state: rm /'
+  rm -vrf "${TEST_GPG_HOMEDIR:?}/${TEST_FOURTH_FILENAME}"   2>&1 | sed 's/^/# unset_current_state: rm /'
 
   # return to the base dir:
   cd "$SECRET_PROJECT_ROOT" || exit 1

--- a/tests/test_add.bats
+++ b/tests/test_add.bats
@@ -246,3 +246,27 @@ function teardown {
   # Cleaning up:
   rm "$filename1" "$filename2" ".gitignore"
 }
+
+@test "run 'add' for file with special chars" {
+  # Preparations:
+  local filename="$TEST_FOURTH_FILENAME"
+  echo "content" > "$filename"
+  echo "$filename" > ".gitignore"
+
+  run git secret add "$filename"
+  [ "$status" -eq 0 ]
+
+  # Ensuring that path mappings was set correctly:
+  local path_mappings
+  path_mappings=$(_get_secrets_dir_paths_mapping)
+
+  local files_list=$(cat "$path_mappings")
+  [ "$files_list" = "$filename" ]
+
+  # Ensuring the file is correctly git-ignored
+  run git check-ignore "$filename"
+  [ "$status" -eq 0 ]
+
+  # Cleaning up:
+  rm "$filename" ".gitignore"
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
running `git secret add [FILENAME]` where `[FILENAME]` contains special characters adds a filename to `.gitignore` that is not properly escaped

this change uses `printf '%q'` to correctly escape the filename before adding it to `.gitignore`

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No
