### PR TITLE
Issue 634 tell duplicate emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Bugfixes
 
 - Escape filenames with special characters before adding to .gitignore
+- Better error handling around telling an email twice (#634)
 
 ### Misc
 
 - Improve documentation about releases
+- Man page improvements
 
 ## Version 0.3.3
 

--- a/man/man1/git-secret-add.1
+++ b/man/man1/git-secret-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-ADD" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-ADD" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-add\fR \- starts to track added files\.

--- a/man/man1/git-secret-cat.1
+++ b/man/man1/git-secret-cat.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CAT" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-CAT" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-cat\fR \- decrypts files passed on command line to stdout

--- a/man/man1/git-secret-changes.1
+++ b/man/man1/git-secret-changes.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CHANGES" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-CHANGES" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-changes\fR \- view diff of the hidden files\.

--- a/man/man1/git-secret-clean.1
+++ b/man/man1/git-secret-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CLEAN" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-CLEAN" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-clean\fR \- removes all the hidden files\.

--- a/man/man1/git-secret-hide.1
+++ b/man/man1/git-secret-hide.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-HIDE" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-HIDE" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-hide\fR \- encrypts all added files with the inner keyring\.

--- a/man/man1/git-secret-init.1
+++ b/man/man1/git-secret-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-INIT" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-INIT" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-init\fR \- initializes git\-secret repository\.

--- a/man/man1/git-secret-killperson.1
+++ b/man/man1/git-secret-killperson.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-KILLPERSON" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-KILLPERSON" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-killperson\fR \- deletes key identified by an email from the inner keyring\.

--- a/man/man1/git-secret-list.1
+++ b/man/man1/git-secret-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-LIST" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-LIST" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-list\fR \- prints all the added files\.

--- a/man/man1/git-secret-remove.1
+++ b/man/man1/git-secret-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REMOVE" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-REMOVE" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-remove\fR \- removes files from index\.

--- a/man/man1/git-secret-reveal.1
+++ b/man/man1/git-secret-reveal.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REVEAL" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-REVEAL" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-reveal\fR \- decrypts all added files\.

--- a/man/man1/git-secret-tell.1
+++ b/man/man1/git-secret-tell.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-TELL" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-TELL" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-tell\fR \- adds a person, who can access private data\.
@@ -15,7 +15,10 @@ git secret tell [\-m] [\-d dir] [emails]\.\.\.
 .fi
 .
 .SH "DESCRIPTION"
-\fBgit\-secret\-tell\fR receives one or more email addresses as an input, searches for the \fBgpg\fR\-key in the \fBgpg\fR \fBhomedir\fR by these emails, then imports the corresponding public key into \fBgit\-secret\fR\'s inner keychain\. From this moment this person can encrypt new files with the keyring which contains their key, but they cannot decrypt the old files, which were already encrypted without their key\. The files should be re\-encrypted with the new keyring by someone who has the unencrypted files\.
+\fBgit\-secret tell\fR receives one or more email addresses as an input, searches for the \fBgpg\fR\-key in the \fBgpg\fR \fBhomedir\fR by these emails, then imports the corresponding public key into \fBgit\-secret\fR\'s inner keychain\. From this moment this person can encrypt new files with the keyring which contains their key, but they cannot decrypt the old files, which were already encrypted without their key\. The files should be re\-encrypted with the new keyring by someone who has the unencrypted files\.
+.
+.P
+Because \fBgit\-secret tell\fR works with only email addresses, it will exit with an error if you have multiple keys in your keychain with specified email addresses, or if one of the specified emails is already associated with a key in the git\-secret keychain\.
 .
 .P
 Versions of \fBgit\-secret tell\fR after 0\.3\.2 will warn about keys that are expired, revoked, or otherwise invalid, and also if multiple keys are found for a single email address\.

--- a/man/man1/git-secret-tell.1.ronn
+++ b/man/man1/git-secret-tell.1.ronn
@@ -7,11 +7,15 @@ git-secret-tell - adds a person, who can access private data.
 
 
 ## DESCRIPTION
-`git-secret-tell` receives one or more email addresses as an input, searches for the `gpg`-key in the `gpg`
+`git-secret tell` receives one or more email addresses as an input, searches for the `gpg`-key in the `gpg`
 `homedir` by these emails, then imports the corresponding public key into `git-secret`'s inner keychain. 
 From this moment this person can encrypt new files with the keyring which contains their key,
 but they cannot decrypt the old files, which were already encrypted without their key. 
 The files should be re-encrypted with the new keyring by someone who has the unencrypted files.
+
+Because `git-secret tell` works with only email addresses, it will exit with an error if you have
+multiple keys in your keychain with specified email addresses, or if one of the specified emails 
+is already associated with a key in the git-secret keychain.
 
 Versions of `git-secret tell` after 0.3.2 will warn about keys that are expired, revoked, or otherwise invalid,
 and also if multiple keys are found for a single email address.

--- a/man/man1/git-secret-usage.1
+++ b/man/man1/git-secret-usage.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-USAGE" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-USAGE" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-usage\fR \- prints all the available commands\.

--- a/man/man1/git-secret-whoknows.1
+++ b/man/man1/git-secret-whoknows.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-WHOKNOWS" "1" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-WHOKNOWS" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-whoknows\fR \- prints email\-labels for each key in the keyring\.

--- a/man/man7/git-secret.7
+++ b/man/man7/git-secret.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET" "7" "November 2020" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET" "7" "January 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\fR \- bash tool to store private data inside a git repo\.

--- a/src/commands/git_secret_killperson.sh
+++ b/src/commands/git_secret_killperson.sh
@@ -28,7 +28,7 @@ function killperson {
   local secrets_dir_keys
   secrets_dir_keys=$(_get_secrets_dir_keys)
 
-  _assert_keychain_contains_emails "$secrets_dir_keys" "${emails[@]}"
+  _assert_keyring_contains_emails "$secrets_dir_keys" "git-secret keyring" "${emails[@]}"
 
   for email in "${emails[@]}"; do
     # see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -67,7 +67,11 @@ function tell {
     _abort "you must use -m or provide at least one email address."
   fi
 
-  _assert_keychain_contains_emails "$homedir" "${emails[@]}"
+  local secrets_dir_keys
+  secrets_dir_keys=$(_get_secrets_dir_keys)
+
+  _assert_keyring_contains_emails "$homedir" "user keyring" "${emails[@]}"
+  _assert_keyring_doesnt_contain_emails "$secrets_dir_keys" "git-secret keyring" "${emails[@]}"
 
   local start_key_cnt
   start_key_cnt=$(get_gpg_key_count)
@@ -95,10 +99,7 @@ function tell {
       _abort "no keyfile found for '$email'. Check your key name: 'gpg --list-keys'."
     fi
 
-    # Importing public key to the local keychain:
-    local secrets_dir_keys
-    secrets_dir_keys=$(_get_secrets_dir_keys)
-
+    # Importing public key to the local keyring:
     local args=( --homedir "$secrets_dir_keys" --no-permission-warning --import "$keyfile" )
     if [[ -z "$_SECRETS_VERBOSE" ]]; then
       $SECRETS_GPG_COMMAND "${args[@]}" > /dev/null 2>&1 3>&-

--- a/tests/test_tell.bats
+++ b/tests/test_tell.bats
@@ -48,6 +48,15 @@ function teardown {
   
 }
 
+@test "run 'tell' on the same email twice" {
+  # first time should succeed
+  git secret tell -d "$TEST_GPG_HOMEDIR" "$TEST_DEFAULT_USER"
+
+  # second time should fail because there's already a key for that email. See #634
+  run git secret tell -d "$TEST_GPG_HOMEDIR" "$TEST_DEFAULT_USER"
+  [ "$status" -ne 0 ]
+}
+
 @test "fail on no users" {
   run _user_required
   [ "$status" -eq 1 ]


### PR DESCRIPTION
Closes #634 by returning an error if you try to `tell` an  email address that currently has access to the git-secret repo.