### PR TITLE
Fix for Issue #638

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Escape filenames with special characters before adding to .gitignore
 - Better error handling around telling an email twice (#634)
+- Fix for killperson if same email is present multiple times (#638)
 
 ### Misc
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -620,7 +620,7 @@ function _assert_keyring_contains_emails_at_least_once {
   local homedir=$1
   local keyring_name=$2
   local emails=$3
-  _assert_keyring_emails "$homedir" "$keyring_name" "$emails" 1 1 # expect the email in the keyring and expect it to be duplicated 
+  _assert_keyring_emails "$homedir" "$keyring_name" "$emails" 1 1 # expect the email at least once in the keyring 
 }
 
 function _assert_keyring_emails {
@@ -628,7 +628,7 @@ function _assert_keyring_emails {
   local keyring_name=$2
   local emails=$3
   local expected=$4  # set this to 0 to not expect the email in the keyring; 1 to expect the email in the keyring
-  local expect_duplicates=$5 # set this to 0 to not allow duplicate emails in the keyring when processing assertion (optional)
+  local allow_duplicates=$5 # set this to 0 to not allow duplicate emails in the keyring when processing assertion (optional)
 
   local gpg_uids
   gpg_uids=$(_get_users_in_gpg_keyring "$homedir")
@@ -646,7 +646,7 @@ function _assert_keyring_emails {
         if [[ $emails_found -eq 0 ]]; then
           _abort "no key found in gpg $keyring_name for: $email"
         elif [[ $emails_found -gt 1 ]]; then
-          if [[ $expect_duplicates -ne 1 ]]; then
+          if [[ $allow_duplicates -ne 1 ]]; then
             _abort "$emails_found keys found in gpg $keyring_name for: $email"
           fi
         fi 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -608,6 +608,7 @@ function _assert_keyring_contains_emails {
   local emails=$3
   _assert_keyring_emails "$homedir" "$keyring_name" "$emails" 1 # 1 here means 'expect $emails in keyring'
 }
+
 function _assert_keyring_doesnt_contain_emails {
   local homedir=$1
   local keyring_name=$2
@@ -615,12 +616,19 @@ function _assert_keyring_doesnt_contain_emails {
   _assert_keyring_emails "$homedir" "$keyring_name" "$emails" 0 # 0 here means 'don't expect $emails in keyring'
 }
 
+function _assert_keyring_contains_emails_at_least_once {
+  local homedir=$1
+  local keyring_name=$2
+  local emails=$3
+  _assert_keyring_emails "$homedir" "$keyring_name" "$emails" 1 1 # expect the email in the keyring and expect it to be duplicated 
+}
 
 function _assert_keyring_emails {
   local homedir=$1
   local keyring_name=$2
   local emails=$3
   local expected=$4  # set this to 0 to not expect the email in the keyring; 1 to expect the email in the keyring
+  local expect_duplicates=$5 # set this to 0 to not allow duplicate emails in the keyring when processing assertion (optional)
 
   local gpg_uids
   gpg_uids=$(_get_users_in_gpg_keyring "$homedir")
@@ -638,7 +646,9 @@ function _assert_keyring_emails {
         if [[ $emails_found -eq 0 ]]; then
           _abort "no key found in gpg $keyring_name for: $email"
         elif [[ $emails_found -gt 1 ]]; then
-          _abort "$emails_found keys found in gpg $keyring_name for: $email"
+          if [[ $expect_duplicates -ne 1 ]]; then
+            _abort "$emails_found keys found in gpg $keyring_name for: $email"
+          fi
         fi 
     else
         if [[ $emails_found -gt 0 ]]; then

--- a/src/commands/git_secret_killperson.sh
+++ b/src/commands/git_secret_killperson.sh
@@ -28,7 +28,7 @@ function killperson {
   local secrets_dir_keys
   secrets_dir_keys=$(_get_secrets_dir_keys)
 
-  _assert_keyring_contains_emails "$secrets_dir_keys" "git-secret keyring" "${emails[@]}"
+  _assert_keyring_contains_emails_at_least_once "$secrets_dir_keys" "git-secret keyring" "${emails[@]}"
 
   for email in "${emails[@]}"; do
     # see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-

--- a/tests/test_killperson.bats
+++ b/tests/test_killperson.bats
@@ -56,6 +56,22 @@ function teardown {
   [ "$status" -eq 1 ]
 }
 
+@test "run 'killperson' with duplicate email" {
+  # Preparations:
+  install_fixture_key "$TEST_DEFAULT_USER"
+
+  local email="$TEST_DEFAULT_USER"
+
+  run git secret killperson "$email"
+  [ "$status" -eq 0 ]
+
+  # Testing output:
+  [[ "$output" == *"$email"* ]]
+
+  # Then whoknows must return an error with status code 1:
+  run git secret whoknows
+  [ "$status" -eq 1 ]
+}
 
 @test "run 'killperson' with multiple arguments" {
   # Adding second user:


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes #638 by adding a `-f` option for killperson to bypass the multiple email check part of _assert_keychain_contains_emails

Does this close any currently open issues?
------------------------------------------
Issue #638 

Any other comments?
-------------------
I added a force option for killperson as it utilizes a shared function necessary for some other commands. Instead of adding a new function, I felt this was the cleanest way. Also wasn't sure how to setup a proper test (how to get 2 of the same email into the git secret state) to allow me to fully test it.
