### PR TITLE
Add check to skip errant new lines in path mapping

### DIFF
--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -47,6 +47,11 @@ function reveal {
 
   if [ ${#to_show[@]} -eq 0 ]; then
     while read -r record; do
+
+      if [[ "$record" == "" ]]; then
+        continue # skip new lines / empty strings
+      fi
+
       to_show+=("$record")  # add record to array
     done < "$path_mappings"
   fi
@@ -76,7 +81,7 @@ function reveal {
         chmod "$perms" "$path"
       fi
     fi
-  
+
   done
 
   _message "done. $counter of ${#to_show[@]} files are revealed."


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .ronn file(s) in man/man*/ to document your changes if appropriate 
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Add a check to array of mapping.cfg records to filter out empty-strings/newlines.

Current implementation doesn't emit any warning that errant new lines in `mapping.cfg` will be processed in `git secret reveal` as `<ROOT_DIR>.secret`.

Ideally the mapping file wouldn't contain any extra new lines, but wanted to address the edge case where it does.

Does this close any currently open issues?
------------------------------------------
https://github.com/sobolevn/git-secret/issues/640

Any relevant logs, error output, etc?
-------------------------------------

Any other comments?
-------------------
Deferring to maintainer opinion on whether a debug message would be helpful here so that user's are warned that their `mapping.cfg` file contains unnecessary newlines.