### PR TITLE
Add security disclaimer for git-secret-killperson specifying what is and is not readable by a user after having been removed from the repository's keyring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Misc
 
+- Add security disclaimer for git-secret-killperson
 - Improve documentation about releases
 - Man page improvements
 

--- a/docs/man/man1/git-secret-killperson.1.ronn
+++ b/docs/man/man1/git-secret-killperson.1.ronn
@@ -11,6 +11,10 @@ This command removes the keys associated with the selected email addresses from 
 If you remove a keypair's access with `git-secret-killperson`, and run `git-secret-reveal` and `git-secret-hide -r`,
 it will be impossible for given users to decrypt the hidden files.
 
+Using git-secret-killperson and re-encrypting the secrets does not prevent a user from extracting secrets that they have previously had access to.
+The old keyrings and the secrets encrypted with them will still be readable by the user in the git history.
+This means that any secrets that the user has had access to at any time must be changed and re-encrypted after their key has been removed from the keyring.
+
 
 ## OPTIONS
 

--- a/man/man1/git-secret-add.1
+++ b/man/man1/git-secret-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-ADD" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-ADD" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-add\fR \- starts to track added files\.

--- a/man/man1/git-secret-cat.1
+++ b/man/man1/git-secret-cat.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CAT" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-CAT" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-cat\fR \- decrypts files passed on command line to stdout

--- a/man/man1/git-secret-changes.1
+++ b/man/man1/git-secret-changes.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CHANGES" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-CHANGES" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-changes\fR \- view diff of the hidden files\.

--- a/man/man1/git-secret-clean.1
+++ b/man/man1/git-secret-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CLEAN" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-CLEAN" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-clean\fR \- removes all the hidden files\.

--- a/man/man1/git-secret-hide.1
+++ b/man/man1/git-secret-hide.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-HIDE" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-HIDE" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-hide\fR \- encrypts all added files with the inner keyring\.

--- a/man/man1/git-secret-init.1
+++ b/man/man1/git-secret-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-INIT" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-INIT" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-init\fR \- initializes git\-secret repository\.

--- a/man/man1/git-secret-killperson.1
+++ b/man/man1/git-secret-killperson.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-KILLPERSON" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-KILLPERSON" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-killperson\fR \- deletes key identified by an email from the inner keyring\.

--- a/man/man1/git-secret-list.1
+++ b/man/man1/git-secret-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-LIST" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-LIST" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-list\fR \- prints all the added files\.

--- a/man/man1/git-secret-remove.1
+++ b/man/man1/git-secret-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REMOVE" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-REMOVE" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-remove\fR \- removes files from index\.

--- a/man/man1/git-secret-reveal.1
+++ b/man/man1/git-secret-reveal.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REVEAL" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-REVEAL" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-reveal\fR \- decrypts all added files\.

--- a/man/man1/git-secret-tell.1
+++ b/man/man1/git-secret-tell.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-TELL" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-TELL" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-tell\fR \- adds a person, who can access private data\.

--- a/man/man1/git-secret-usage.1
+++ b/man/man1/git-secret-usage.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-USAGE" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-USAGE" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-usage\fR \- prints all the available commands\.

--- a/man/man1/git-secret-whoknows.1
+++ b/man/man1/git-secret-whoknows.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-WHOKNOWS" "1" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET\-WHOKNOWS" "1" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\-whoknows\fR \- prints email\-labels for each key in the keyring\.

--- a/man/man7/git-secret.7
+++ b/man/man7/git-secret.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET" "7" "January 2021" "sobolevn" "git-secret 0.3.3"
+.TH "GIT\-SECRET" "7" "April 2021" "sobolevn" "git-secret 0.3.3"
 .
 .SH "NAME"
 \fBgit\-secret\fR \- bash tool to store private data inside a git repo\.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .ronn file(s) in man/man*/ to document your changes if appropriate 
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adds security disclaimer for `git-secret-killperson` specifying what is and is not readable by a user after having been removed from the repository's keyring.

Does this close any currently open issues?
------------------------------------------
Closes #653 