### PR TITLE
Issue 630 hide armored2

### DIFF
--- a/.ci/docker-ci/alpine/Dockerfile
+++ b/.ci/docker-ci/alpine/Dockerfile
@@ -12,5 +12,6 @@ RUN apk add --no-cache --update \
   git \
   gnupg \
   # Assumed to be present:
+  file \
   make \
   procps

--- a/.ci/docker-ci/centos/Dockerfile
+++ b/.ci/docker-ci/centos/Dockerfile
@@ -12,6 +12,7 @@ RUN dnf -y update \
     gnupg \
     # Assumed to be present:
     diffutils \
+    file \
     findutils \
     procps \
     make \

--- a/.ci/docker-ci/debian-gnupg1/Dockerfile
+++ b/.ci/docker-ci/debian-gnupg1/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     git \
     gnupg1 \
     # Assumed to be present:
+    file \
     procps \
     make \
   # Cleaning cache:

--- a/.ci/docker-ci/debian-gnupg2/Dockerfile
+++ b/.ci/docker-ci/debian-gnupg2/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     git \
     gnupg \
     # Assumed to be present:
+    file \
     procps \
     make \
   # Cleaning cache:

--- a/.ci/docker-ci/fedora/Dockerfile
+++ b/.ci/docker-ci/fedora/Dockerfile
@@ -12,6 +12,7 @@ RUN dnf -y update \
     gnupg \
     # Assumed to be present:
     diffutils \
+    file \
     findutils \
     procps \
     make \

--- a/.ci/docker-ci/ubuntu/Dockerfile
+++ b/.ci/docker-ci/ubuntu/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     git \
     gnupg \
     # Assumed to be present:
+    file \
     procps \
     make \
   # Cleaning cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add security disclaimer for git-secret-killperson
 - Improve documentation about releases
 - Man page improvements
+- Use gpg --armor when encrypting files, so secret files are txt (#631)
 
 ## Version 0.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## {{Next Version}}
 
+### Features
+
+- Adds `SECRETS_GPG_ARMOR` env variable to use `gpg --armor`
+  when encrypting files, so secret files will stored
+  in text format rather than binary (#631)
+
 ### Bugfixes
 
 - Fix adding newlines to `.gitignore` entries (#643)
@@ -30,7 +36,7 @@
 - Add security disclaimer for git-secret-killperson
 - Improve documentation about releases
 - Man page improvements
-- Use gpg --armor when encrypting files, so secret files are txt (#631)
+
 
 ## Version 0.3.3
 

--- a/man/man1/git-secret-add.1
+++ b/man/man1/git-secret-add.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-ADD" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-ADD" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-add\fR \- starts to track added files\.
@@ -15,10 +15,10 @@ git secret add [\-v] [\-i] <pathspec>\.\.\.
 .fi
 .
 .SH "DESCRIPTION"
-\fBgit\-secret\-add\fR adds a filepath(s) into \fB\.gitsecret/paths/mapping\.cfg\fR and ensures the filepath is mentioned \.gitignore\.
+\fBgit\-secret\-add\fR adds a filepath(s) into \fB\.gitsecret/paths/mapping\.cfg\fR and ensures the filepath is mentioned \fB\.gitignore\fR\.
 .
 .P
-When adding files to encrypt, \fBgit\-secret\-add\fR (as of 0\.2\.6) will ensure that they are ignored by \fBgit\fR by mentioning them in \.gitignore, since they must be secure and not be committed into the remote repository unencrypted\.
+When adding files to encrypt, \fBgit\-secret\-add\fR (as of 0\.2\.6) will ensure that they are ignored by \fBgit\fR by mentioning them in \fB\.gitignore\fR, since they must be secure and not be committed into the remote repository unencrypted\.
 .
 .P
 If there\'s no users in the \fBgit\-secret\fR\'s keyring, when adding a file, an exception will be raised\.

--- a/man/man1/git-secret-add.1.md
+++ b/man/man1/git-secret-add.1.md
@@ -8,10 +8,10 @@ git-secret-add - starts to track added files.
 
 ## DESCRIPTION
 `git-secret-add` adds a filepath(s) into `.gitsecret/paths/mapping.cfg`
-and ensures the filepath is mentioned .gitignore.
+and ensures the filepath is mentioned `.gitignore`.
 
 When adding files to encrypt, `git-secret-add` (as of 0.2.6) will ensure that they are ignored by `git` by mentioning
-them in .gitignore, since they must be secure and not be committed into the remote repository unencrypted.
+them in `.gitignore`, since they must be secure and not be committed into the remote repository unencrypted.
 
 If there's no users in the `git-secret`'s keyring, when adding a file, an exception will be raised.
 
@@ -35,5 +35,5 @@ Run `man git-secret-add` to see this note.
 
 ## SEE ALSO
 
-[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-tell(1)](http://git-secret.io/git-secret-tell), 
+[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-tell(1)](http://git-secret.io/git-secret-tell),
 [git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal)

--- a/man/man1/git-secret-cat.1
+++ b/man/man1/git-secret-cat.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CAT" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-CAT" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-cat\fR \- decrypts files passed on command line to stdout

--- a/man/man1/git-secret-cat.1.md
+++ b/man/man1/git-secret-cat.1.md
@@ -8,7 +8,7 @@ git-secret-cat - decrypts files passed on command line to stdout
 
 ## DESCRIPTION
 `git-secret-cat` - Outputs to stdout the contents of the files named on the command line.
-As with `git-secret-reveal`, you'll need to have a public/private keypair that is allowed to 
+As with `git-secret-reveal`, you'll need to have a public/private keypair that is allowed to
 decrypt this repo.
 
 Note also that this command can be affected by the `SECRETS_PINENTRY` environment variable. See

--- a/man/man1/git-secret-changes.1
+++ b/man/man1/git-secret-changes.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CHANGES" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-CHANGES" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-changes\fR \- view diff of the hidden files\.

--- a/man/man1/git-secret-changes.1.md
+++ b/man/man1/git-secret-changes.1.md
@@ -7,8 +7,8 @@ git-secret-changes - view diff of the hidden files.
 
 
 ## DESCRIPTION
-`git-secret-changes` - shows changes between the current version of hidden files and the ones already committed. 
-You can provide any number of hidden files to this command as arguments, and it will show changes for these files only. 
+`git-secret-changes` - shows changes between the current version of hidden files and the ones already committed.
+You can provide any number of hidden files to this command as arguments, and it will show changes for these files only.
 Note that files must be specified by their encrypted names, typically `filename.yml.secret`.
 If no arguments are provided, information about all hidden files will be shown.
 
@@ -30,6 +30,6 @@ Run `man git-secret-changes` to see this note.
 
 ## SEE ALSO
 
-[git-secret-add(1)](http://git-secret.io/git-secret-add), [git-secret-tell(1)](http://git-secret.io/git-secret-tell), 
-[git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal), 
+[git-secret-add(1)](http://git-secret.io/git-secret-add), [git-secret-tell(1)](http://git-secret.io/git-secret-tell),
+[git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal),
 [git-secret-cat(1)](http://git-secret.io/git-secret-cat)

--- a/man/man1/git-secret-clean.1
+++ b/man/man1/git-secret-clean.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-CLEAN" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-CLEAN" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-clean\fR \- removes all the hidden files\.
@@ -15,7 +15,7 @@ git secret clean [\-v]
 .fi
 .
 .SH "DESCRIPTION"
-\fBgit\-secret\-clean\fR deletes all the encrypted files\. Verbose output is enabled with the \-v option, in which case the program prints which files are deleted\.
+\fBgit\-secret\-clean\fR deletes all the encrypted files\. Verbose output is enabled with the \fB\-v\fR option, in which case the program prints which files are deleted\.
 .
 .SH "OPTIONS"
 .

--- a/man/man1/git-secret-clean.1.md
+++ b/man/man1/git-secret-clean.1.md
@@ -7,13 +7,13 @@ git-secret-clean - removes all the hidden files.
 
 
 ## DESCRIPTION
-`git-secret-clean` deletes all the encrypted files. 
-Verbose output is enabled with the -v option, in which case the program prints which files are deleted.
+`git-secret-clean` deletes all the encrypted files.
+Verbose output is enabled with the `-v` option, in which case the program prints which files are deleted.
 
 
 ## OPTIONS
 
-    -v  - verbose mode, shows which files are deleted. 
+    -v  - verbose mode, shows which files are deleted.
     -h  - shows this help.
 
 You can also enable verbosity using the SECRETS_VERBOSE environment variable,
@@ -26,5 +26,5 @@ Run `man git-secret-clean` to see this note.
 
 ## SEE ALSO
 
-[git-secret-whoknows(1)](http://git-secret.io/git-secret-whoknows), [git-secret-add(1)](http://git-secret.io/git-secret-add), 
+[git-secret-whoknows(1)](http://git-secret.io/git-secret-whoknows), [git-secret-add(1)](http://git-secret.io/git-secret-add),
 [git-secret-remove(1)](http://git-secret.io/git-secret-remove), [git-secret-removeperson(1)](http://git-secret.io/git-secret-removeperson)

--- a/man/man1/git-secret-hide.1
+++ b/man/man1/git-secret-hide.1
@@ -18,16 +18,16 @@ git secret hide [\-c] [\-F] [\-P] [\-v] [\-d] [\-m]
 \fBgit\-secret\-hide\fR creates an encrypted version (typically called \fBfilename\.txt\.secret\fR) of each file added by \fBgit\-secret\-add\fR command\. Now anyone enabled via \'git secret tell\' can can decrypt these files\. Under the hood, \fBgit\-secret\fR uses the keyring in \fB\.gitsecret/keys\fR and user\'s secret keys to decrypt the files\.
 .
 .P
-It is recommended to encrypt (or re\-encrypt) all the files in a git\-secret repo each time \fBgit secret hide\fR is run\.
+It is recommended to encrypt (or re\-encrypt) all the files in a \fBgit\-secret\fR repo each time \fBgit secret hide\fR is run\.
 .
 .P
 Otherwise the keychain (the one stored in \fB\.gitsecret/keys/*\.gpg\fR), may have changed since the last time the files were encrypted, and it\'s possible to create a state where the users in the output of \fBgit secret whoknows\fR may not be able to decrypt the some files in the repo, or may be able decrypt files they\'re not supposed to be able to\.
 .
 .P
-In other words, unless you re\-encrypt all the files in a repo each time you \'hide\' any, it\'s possible to make it so some files can no longer be decrypted by users who should be (and would appear) able to decrypt them, and vice\-versa\.
+In other words, unless you re\-encrypt all the files in a repo each time you \fBhide\fR any, it\'s possible to make it so some files can no longer be decrypted by users who should be (and would appear) able to decrypt them, and vice\-versa\.
 .
 .P
-If you know what you are doing and wish to encrypt or re\-encrypt only a subset of the files even after reading the above paragraphs, you can use the \fB\-F\fR or \fB\-m\fR option to only encrypted a subset of files\. The \fB\-F\fR option forces \fBgit secret hide\fR to skip any hidden files where the unencrypted versions aren\'t present\. The \fB\-m\fR option skips any hidden files that have not be modified since the last time they were encrypted\.
+If you know what you are doing and wish to encrypt or re\-encrypt only a subset of the files even after reading the above paragraphs, you can use the \fB\-F\fR or \fB\-m\fR options\. The \fB\-F\fR option forces \fBgit secret hide\fR to skip any hidden files where the unencrypted versions aren\'t present\. The \fB\-m\fR option skips any hidden files that have not be been modified since the last time they were encrypted\.
 .
 .SH "OPTIONS"
 .
@@ -46,22 +46,22 @@ If you know what you are doing and wish to encrypt or re\-encrypt only a subset 
 .SH "ENV VARIABLES"
 .
 .IP "\(bu" 4
-\fBSECRETS_GPG_COMMAND\fR to change the default \fBgpg\fR command to anything else
+\fBSECRETS_GPG_COMMAND\fR changes the default \fBgpg\fR command to anything else
 .
 .IP "\(bu" 4
-\fBSECRETS_GPG_ARMOR\fR boolean to enable \fB\-\-armor\fR mode \fIhttps://www\.gnupg\.org/gph/en/manual/r1290\.html\fR to store secrets in text format over binary
+\fBSECRETS_GPG_ARMOR\fR is a boolean to enable \fB\-\-armor\fR mode \fIhttps://www\.gnupg\.org/gph/en/manual/r1290\.html\fR to store secrets in text format over binary
 .
 .IP "\(bu" 4
-\fBSECRETS_DIR\fR to change the default \fB\.gitsecret/\fR folder to another name as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+\fBSECRETS_DIR\fR changes the default \fB\.gitsecret/\fR folder to another name as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
 .
 .IP "\(bu" 4
-\fBSECRETS_EXTENSION\fR to change the default \fB\.secret\fR file extension
+\fBSECRETS_EXTENSION\fR changes the default \fB\.secret\fR file extension
 .
 .IP "\(bu" 4
-\fBSECRETS_VERBOSE\fR to change the output verbosity as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+\fBSECRETS_VERBOSE\fR changes the output verbosity as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
 .
 .IP "\(bu" 4
-\fBSECRETS_PINENTRY\fR to change the \fBgpg \-\-pinentry\fR mode \fIhttps://github\.com/gpg/pinentry\fR as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+\fBSECRETS_PINENTRY\fR changes the \fBgpg \-\-pinentry\fR mode \fIhttps://github\.com/gpg/pinentry\fR as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
 .
 .IP "" 0
 .

--- a/man/man1/git-secret-hide.1
+++ b/man/man1/git-secret-hide.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-HIDE" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-HIDE" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-hide\fR \- encrypts all added files with the inner keyring\.
@@ -27,16 +27,7 @@ Otherwise the keychain (the one stored in \fB\.gitsecret/keys/*\.gpg\fR), may ha
 In other words, unless you re\-encrypt all the files in a repo each time you \'hide\' any, it\'s possible to make it so some files can no longer be decrypted by users who should be (and would appear) able to decrypt them, and vice\-versa\.
 .
 .P
-If you know what you are doing and wish to encrypt or re\-encrypt only a subset of the files even after reading the above paragraphs, you can use the \-F or \-m option to only encrypted a subset of files\. The \-F option forces \fBgit secret hide\fR to skip any hidden files where the unencrypted versions aren\'t present\. The \-m option skips any hidden files that have not be modified since the last time they were encrypted\.
-.
-.P
-Also, it is possible to modify the names of the encrypted files by setting \fBSECRETS_EXTENSION\fR variable\.
-.
-.P
-(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder using the SECRETS_DIR environment variable\.
-.
-.P
-You can also enable verbosity using the SECRETS_VERBOSE environment variable, as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+If you know what you are doing and wish to encrypt or re\-encrypt only a subset of the files even after reading the above paragraphs, you can use the \fB\-F\fR or \fB\-m\fR option to only encrypted a subset of files\. The \fB\-F\fR option forces \fBgit secret hide\fR to skip any hidden files where the unencrypted versions aren\'t present\. The \fB\-m\fR option skips any hidden files that have not be modified since the last time they were encrypted\.
 .
 .SH "OPTIONS"
 .
@@ -52,11 +43,30 @@ You can also enable verbosity using the SECRETS_VERBOSE environment variable, as
 .
 .fi
 .
+.SH "ENV VARIABLES"
+.
+.IP "\(bu" 4
+\fBSECRETS_GPG_COMMAND\fR to change the default \fBgpg\fR command to anything else
+.
+.IP "\(bu" 4
+\fBSECRETS_GPG_ARMOR\fR boolean to enable \fB\-\-armor\fR mode \fIhttps://www\.gnupg\.org/gph/en/manual/r1290\.html\fR to store secrets in text format over binary
+.
+.IP "\(bu" 4
+\fBSECRETS_DIR\fR to change the default \fB\.gitsecret/\fR folder to another name as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+.
+.IP "\(bu" 4
+\fBSECRETS_EXTENSION\fR to change the default \fB\.secret\fR file extension
+.
+.IP "\(bu" 4
+\fBSECRETS_VERBOSE\fR to change the output verbosity as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+.
+.IP "\(bu" 4
+\fBSECRETS_PINENTRY\fR to change the \fBgpg \-\-pinentry\fR mode \fIhttps://github\.com/gpg/pinentry\fR as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+.
+.IP "" 0
+.
 .SH "MANUAL"
 Run \fBman git\-secret\-hide\fR to see this note\.
 .
 .SH "SEE ALSO"
-git\-secret\-init(1) \fIhttp://git\-secret\.io/git\-secret\-init\fR, git\-secret\-tell(1) \fIhttp://git\-secret\.io/git\-secret\-tell\fR, git\-secret\-add(1) \fIhttp://git\-secret\.io/git\-secret\-add\fR, git\-secret\-reveal(1) \fIhttp://git\-secret\.io/git\-secret\-reveal\fR,
-.
-.br
-git\-secret\-cat(1) \fIhttp://git\-secret\.io/git\-secret\-cat\fR
+git\-secret\-init(1) \fIhttp://git\-secret\.io/git\-secret\-init\fR, git\-secret\-tell(1) \fIhttp://git\-secret\.io/git\-secret\-tell\fR, git\-secret\-add(1) \fIhttp://git\-secret\.io/git\-secret\-add\fR, git\-secret\-reveal(1) \fIhttp://git\-secret\.io/git\-secret\-reveal\fR, git\-secret\-cat(1) \fIhttp://git\-secret\.io/git\-secret\-cat\fR

--- a/man/man1/git-secret-hide.1.md
+++ b/man/man1/git-secret-hide.1.md
@@ -12,7 +12,7 @@ of each file added by `git-secret-add` command.
 Now anyone enabled via 'git secret tell' can can decrypt these files. Under the hood,
 `git-secret` uses the keyring in `.gitsecret/keys` and user's secret keys to decrypt the files.
 
-It is recommended to encrypt (or re-encrypt) all the files in a git-secret repo each
+It is recommended to encrypt (or re-encrypt) all the files in a `git-secret` repo each
 time `git secret hide` is run.
 
 Otherwise the keychain (the one stored in `.gitsecret/keys/*.gpg`),
@@ -21,15 +21,17 @@ to create a state where the users in the output of `git secret whoknows`
 may not be able to decrypt the some files in the repo, or may be able decrypt files
 they're not supposed to be able to.
 
-In other words, unless you re-encrypt all the files in a repo each time you 'hide' any,
+In other words, unless you re-encrypt all the files in a repo each time you `hide` any,
 it's possible to make it so some files can no longer be decrypted by users who should be
 (and would appear) able to decrypt them, and vice-versa.
 
-If you know what you are doing and wish to encrypt or re-encrypt only a subset of the files
-even after reading the above paragraphs, you can use the `-F` or `-m` option to only encrypted
-a subset of files. The `-F` option forces `git secret hide` to skip any hidden files
-where the unencrypted versions aren't present. The `-m` option skips any hidden files that have
-not be modified since the last time they were encrypted.
+If you know what you are doing and wish
+to encrypt or re-encrypt only a subset of the files
+even after reading the above paragraphs, you can use the `-F` or `-m` options.
+The `-F` option forces `git secret hide` to skip any hidden files
+where the unencrypted versions aren't present.
+The `-m` option skips any hidden files that have
+not be been modified since the last time they were encrypted.
 
 
 ## OPTIONS
@@ -45,12 +47,12 @@ not be modified since the last time they were encrypted.
 
 ## ENV VARIABLES
 
-- `SECRETS_GPG_COMMAND` to change the default `gpg` command to anything else
-- `SECRETS_GPG_ARMOR` boolean to enable [`--armor` mode](https://www.gnupg.org/gph/en/manual/r1290.html) to store secrets in text format over binary
-- `SECRETS_DIR` to change the default `.gitsecret/` folder to another name as documented at [git-secret(7)](http://git-secret.io/)
-- `SECRETS_EXTENSION` to change the default `.secret` file extension
-- `SECRETS_VERBOSE` to change the output verbosity as documented at [git-secret(7)](http://git-secret.io/)
-- `SECRETS_PINENTRY` to change the [`gpg --pinentry` mode](https://github.com/gpg/pinentry) as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_GPG_COMMAND` changes the default `gpg` command to anything else
+- `SECRETS_GPG_ARMOR` is a boolean to enable [`--armor` mode](https://www.gnupg.org/gph/en/manual/r1290.html) to store secrets in text format over binary
+- `SECRETS_DIR` changes the default `.gitsecret/` folder to another name as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_EXTENSION` changes the default `.secret` file extension
+- `SECRETS_VERBOSE` changes the output verbosity as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_PINENTRY` changes the [`gpg --pinentry` mode](https://github.com/gpg/pinentry) as documented at [git-secret(7)](http://git-secret.io/)
 
 
 ## MANUAL

--- a/man/man1/git-secret-hide.1.md
+++ b/man/man1/git-secret-hide.1.md
@@ -7,37 +7,29 @@ git-secret-hide - encrypts all added files with the inner keyring.
 
 
 ## DESCRIPTION
-`git-secret-hide` creates an encrypted version (typically called `filename.txt.secret`) 
-of each file added by `git-secret-add` command. 
+`git-secret-hide` creates an encrypted version (typically called `filename.txt.secret`)
+of each file added by `git-secret-add` command.
 Now anyone enabled via 'git secret tell' can can decrypt these files. Under the hood,
 `git-secret` uses the keyring in `.gitsecret/keys` and user's secret keys to decrypt the files.
 
-It is recommended to encrypt (or re-encrypt) all the files in a git-secret repo each 
+It is recommended to encrypt (or re-encrypt) all the files in a git-secret repo each
 time `git secret hide` is run.
 
 Otherwise the keychain (the one stored in `.gitsecret/keys/*.gpg`),
-may have changed since the last time the files were encrypted, and it's possible 
-to create a state where the users in the output of `git secret whoknows` 
-may not be able to decrypt the some files in the repo, or may be able decrypt files 
+may have changed since the last time the files were encrypted, and it's possible
+to create a state where the users in the output of `git secret whoknows`
+may not be able to decrypt the some files in the repo, or may be able decrypt files
 they're not supposed to be able to.
 
-In other words, unless you re-encrypt all the files in a repo each time you 'hide' any, 
-it's possible to make it so some files can no longer be decrypted by users who should be 
+In other words, unless you re-encrypt all the files in a repo each time you 'hide' any,
+it's possible to make it so some files can no longer be decrypted by users who should be
 (and would appear) able to decrypt them, and vice-versa.
 
-If you know what you are doing and wish to encrypt or re-encrypt only a subset of the files 
-even after reading the above paragraphs, you can use the -F or -m option to only encrypted 
-a subset of files. The -F option forces `git secret hide` to skip any hidden files 
-where the unencrypted versions aren't present. The -m option skips any hidden files that have 
-not be modified since the last time they were encrypted. 
-
-Also, it is possible to modify the names of the encrypted files by setting `SECRETS_EXTENSION` variable.
-
-(See [git-secret(7)](http://git-secret.io/git-secret) for information about renaming the .gitsecret
-folder using the SECRETS_DIR environment variable.
-
-You can also enable verbosity using the SECRETS_VERBOSE environment variable,
-as documented at [git-secret(7)](http://git-secret.io/)
+If you know what you are doing and wish to encrypt or re-encrypt only a subset of the files
+even after reading the above paragraphs, you can use the `-F` or `-m` option to only encrypted
+a subset of files. The `-F` option forces `git secret hide` to skip any hidden files
+where the unencrypted versions aren't present. The `-m` option skips any hidden files that have
+not be modified since the last time they were encrypted.
 
 
 ## OPTIONS
@@ -50,6 +42,17 @@ as documented at [git-secret(7)](http://git-secret.io/)
     -m  - encrypt files only when modified.
     -h  - shows help.
 
+
+## ENV VARIABLES
+
+- `SECRETS_GPG_COMMAND` to change the default `gpg` command to anything else
+- `SECRETS_GPG_ARMOR` boolean to enable [`--armor` mode](https://www.gnupg.org/gph/en/manual/r1290.html) to store secrets in text format over binary
+- `SECRETS_DIR` to change the default `.gitsecret/` folder to another name as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_EXTENSION` to change the default `.secret` file extension
+- `SECRETS_VERBOSE` to change the output verbosity as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_PINENTRY` to change the [`gpg --pinentry` mode](https://github.com/gpg/pinentry) as documented at [git-secret(7)](http://git-secret.io/)
+
+
 ## MANUAL
 
 Run `man git-secret-hide` to see this note.
@@ -57,6 +60,6 @@ Run `man git-secret-hide` to see this note.
 
 ## SEE ALSO
 
-[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-tell(1)](http://git-secret.io/git-secret-tell), 
-[git-secret-add(1)](http://git-secret.io/git-secret-add), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal),  
+[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-tell(1)](http://git-secret.io/git-secret-tell),
+[git-secret-add(1)](http://git-secret.io/git-secret-add), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal),
 [git-secret-cat(1)](http://git-secret.io/git-secret-cat)

--- a/man/man1/git-secret-init.1
+++ b/man/man1/git-secret-init.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-INIT" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-INIT" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-init\fR \- initializes git\-secret repository\.
@@ -18,10 +18,10 @@ git secret init
 \fBgit\-secret\-init\fR should be run inside a \fBgit\fR repo to set up the \.gitsecret directory and initialize the repo for git\-secret\. Until repository is initialized with \fBgit secret init\fR, all other \fBgit\-secret\fR commands are unavailable\.
 .
 .P
-If a \.gitsecret directory already exists, \fBgit\-secret\-init\fR exits without making any changes\. Otherwise, a \.gitsecret directory is created with appropriate sub\-directories, and patterns to ignore git\-secret\'s \fBrandom_seed_file\fR and not ignore \fB\.secret\fR files are added to \fB\.gitignore\fR\.
+If a \fB\.gitsecret\fR directory already exists, \fBgit\-secret\-init\fR exits without making any changes\. Otherwise, a \.gitsecret directory is created with appropriate sub\-directories, and patterns to ignore \fBgit\-secret\fR\'s \fBrandom_seed_file\fR and not ignore \fB\.secret\fR files are added to \fB\.gitignore\fR\.
 .
 .P
-(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder with the SECRETS_DIR environment variable, and changing the extension git\-secret uses for secret files with the SECRETS_EXTENSION environment variable\.
+(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder with the \fBSECRETS_DIR\fR environment variable, and changing the extension \fBgit\-secret\fR uses for secret files with the \fBSECRETS_EXTENSION\fR environment variable\.
 .
 .SH "OPTIONS"
 .

--- a/man/man1/git-secret-init.1.md
+++ b/man/man1/git-secret-init.1.md
@@ -10,14 +10,14 @@ git-secret-init - initializes git-secret repository.
 `git-secret-init` should be run inside a `git` repo to set up the .gitsecret directory and initialize the repo for git-secret.
 Until repository is initialized with `git secret init`, all other `git-secret` commands are unavailable.
 
-If a .gitsecret directory already exists, `git-secret-init` exits without making any changes.
+If a `.gitsecret` directory already exists, `git-secret-init` exits without making any changes.
 Otherwise, a .gitsecret directory is created with appropriate sub-directories,
-and patterns to ignore git-secret's `random_seed_file`
-and not ignore `.secret` files are added to `.gitignore`.  
+and patterns to ignore `git-secret`'s `random_seed_file`
+and not ignore `.secret` files are added to `.gitignore`.
 
 (See [git-secret(7)](http://git-secret.io/git-secret) for information about renaming the .gitsecret
-folder with the SECRETS_DIR environment variable, and changing the extension git-secret uses for secret files
-with the SECRETS_EXTENSION environment variable.
+folder with the `SECRETS_DIR` environment variable, and changing the extension `git-secret` uses for secret files
+with the `SECRETS_EXTENSION` environment variable.
 
 
 ## OPTIONS

--- a/man/man1/git-secret-list.1
+++ b/man/man1/git-secret-list.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-LIST" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-LIST" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-list\fR \- prints all the added files\.
@@ -18,7 +18,7 @@ git secret list
 \fBgit\-secret\-list\fR prints all the currently added tracked files from the \fB\.gitsecret/paths/mapping\.cfg\fR\.
 .
 .P
-(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder using the SECRETS_DIR environment variable\.
+(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder using the \fBSECRETS_DIR\fR environment variable\.
 .
 .SH "OPTIONS"
 .

--- a/man/man1/git-secret-list.1.md
+++ b/man/man1/git-secret-list.1.md
@@ -10,7 +10,7 @@ git-secret-list - prints all the added files.
 `git-secret-list` prints all the currently added tracked files from the `.gitsecret/paths/mapping.cfg`.
 
 (See [git-secret(7)](http://git-secret.io/git-secret) for information about renaming the .gitsecret
-folder using the SECRETS_DIR environment variable.
+folder using the `SECRETS_DIR` environment variable.
 
 
 ## OPTIONS
@@ -25,6 +25,6 @@ Run `man git-secret-list` to see this note.
 
 ## SEE ALSO
 
-[git-secret-whoknows(1)](http://git-secret.io/git-secret-whoknows), [git-secret-add(1)](http://git-secret.io/git-secret-add), 
-[git-secret-remove(1)](http://git-secret.io/git-secret-remove), [git-secret-hide(1)](http://git-secret.io/git-secret-hide), 
+[git-secret-whoknows(1)](http://git-secret.io/git-secret-whoknows), [git-secret-add(1)](http://git-secret.io/git-secret-add),
+[git-secret-remove(1)](http://git-secret.io/git-secret-remove), [git-secret-hide(1)](http://git-secret.io/git-secret-hide),
 [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal), [git-secret-cat(1)](http://git-secret.io/git-secret-cat)

--- a/man/man1/git-secret-remove.1
+++ b/man/man1/git-secret-remove.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REMOVE" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-REMOVE" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-remove\fR \- removes files from index\.
@@ -18,7 +18,7 @@ git secret remove [\-c] <pathspec>\.\.\.
 \fBgit\-secret\-remove\fR deletes files from \fB\.gitsecret/paths/mapping\.cfg\fR, so they won\'t be encrypted or decrypted in the future\. There\'s also a \-c option to delete existing encrypted versions of the files provided\.
 .
 .P
-(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder using the SECRETS_DIR environment variable\.
+(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder using the \fBSECRETS_DIR\fR environment variable\.
 .
 .SH "OPTIONS"
 .

--- a/man/man1/git-secret-remove.1.md
+++ b/man/man1/git-secret-remove.1.md
@@ -7,12 +7,12 @@ git-secret-remove - removes files from index.
 
 
 ## DESCRIPTION
-`git-secret-remove` deletes files from `.gitsecret/paths/mapping.cfg`, 
-so they won't be encrypted or decrypted in the future. 
+`git-secret-remove` deletes files from `.gitsecret/paths/mapping.cfg`,
+so they won't be encrypted or decrypted in the future.
 There's also a -c option to delete existing encrypted versions of the files provided.
 
 (See [git-secret(7)](http://git-secret.io/git-secret) for information about renaming the .gitsecret
-folder using the SECRETS_DIR environment variable.
+folder using the `SECRETS_DIR` environment variable.
 
 
 ## OPTIONS
@@ -28,5 +28,5 @@ Run `man git-secret-remove` to see this note.
 
 ## SEE ALSO
 
-[git-secret-add(1)](http://git-secret.io/git-secret-add), [git-secret-clean(1)](http://git-secret.io/git-secret-clean), 
+[git-secret-add(1)](http://git-secret.io/git-secret-add), [git-secret-clean(1)](http://git-secret.io/git-secret-clean),
 [git-secret-removeperson(1)](http://git-secret.io/git-secret-removeperson)

--- a/man/man1/git-secret-removeperson.1
+++ b/man/man1/git-secret-removeperson.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REMOVEPERSON" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-REMOVEPERSON" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-removeperson\fR \- deletes key identified by an email from the inner keyring\.

--- a/man/man1/git-secret-removeperson.1.md
+++ b/man/man1/git-secret-removeperson.1.md
@@ -7,7 +7,7 @@ git-secret-removeperson - deletes key identified by an email from the inner keyr
 
 
 ## DESCRIPTION
-This command removes the keys associated with the selected email addresses from the keyring. 
+This command removes the keys associated with the selected email addresses from the keyring.
 If you remove a keypair's access with `git-secret-removeperson`, and run `git-secret-reveal` and `git-secret-hide -r`,
 it will be impossible for given users to decrypt the hidden files.
 

--- a/man/man1/git-secret-reveal.1
+++ b/man/man1/git-secret-reveal.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-REVEAL" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-REVEAL" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-reveal\fR \- decrypts all added files\.
@@ -31,8 +31,27 @@ git secret reveal [\-f] [\-F] [\-P] [\-v] [\-d dir] [\-p password] [pathspec]\.\
 .
 .fi
 .
-.P
-(See git\-secret(7) \fIhttp://git\-secret\.io/git\-secret\fR for information about renaming the \.gitsecret folder using the SECRETS_DIR environment variable\.
+.SH "ENV VARIABLES"
+.
+.IP "\(bu" 4
+\fBSECRETS_GPG_COMMAND\fR to change the default \fBgpg\fR command to anything else
+.
+.IP "\(bu" 4
+\fBSECRETS_GPG_ARMOR\fR boolean to enable \fB\-\-armor\fR mode \fIhttps://www\.gnupg\.org/gph/en/manual/r1290\.html\fR to store secrets in text format over binary
+.
+.IP "\(bu" 4
+\fBSECRETS_DIR\fR to change the default \fB\.gitsecret/\fR folder to another name as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+.
+.IP "\(bu" 4
+\fBSECRETS_EXTENSION\fR to change the default \fB\.secret\fR file extension
+.
+.IP "\(bu" 4
+\fBSECRETS_VERBOSE\fR to change the output verbosity as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+.
+.IP "\(bu" 4
+\fBSECRETS_PINENTRY\fR to change the \fBgpg \-\-pinentry\fR mode \fIhttps://github\.com/gpg/pinentry\fR as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+.
+.IP "" 0
 .
 .SH "MANUAL"
 Run \fBman git\-secret\-reveal\fR to see this note\.

--- a/man/man1/git-secret-reveal.1
+++ b/man/man1/git-secret-reveal.1
@@ -34,22 +34,22 @@ git secret reveal [\-f] [\-F] [\-P] [\-v] [\-d dir] [\-p password] [pathspec]\.\
 .SH "ENV VARIABLES"
 .
 .IP "\(bu" 4
-\fBSECRETS_GPG_COMMAND\fR to change the default \fBgpg\fR command to anything else
+\fBSECRETS_GPG_COMMAND\fR changes the default \fBgpg\fR command to anything else
 .
 .IP "\(bu" 4
-\fBSECRETS_GPG_ARMOR\fR boolean to enable \fB\-\-armor\fR mode \fIhttps://www\.gnupg\.org/gph/en/manual/r1290\.html\fR to store secrets in text format over binary
+\fBSECRETS_GPG_ARMOR\fR is a boolean to enable \fB\-\-armor\fR mode \fIhttps://www\.gnupg\.org/gph/en/manual/r1290\.html\fR to store secrets in text format over binary
 .
 .IP "\(bu" 4
-\fBSECRETS_DIR\fR to change the default \fB\.gitsecret/\fR folder to another name as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+\fBSECRETS_DIR\fR changes the default \fB\.gitsecret/\fR folder to another name as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
 .
 .IP "\(bu" 4
-\fBSECRETS_EXTENSION\fR to change the default \fB\.secret\fR file extension
+\fBSECRETS_EXTENSION\fR changes the default \fB\.secret\fR file extension
 .
 .IP "\(bu" 4
-\fBSECRETS_VERBOSE\fR to change the output verbosity as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+\fBSECRETS_VERBOSE\fR changes the output verbosity as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
 .
 .IP "\(bu" 4
-\fBSECRETS_PINENTRY\fR to change the \fBgpg \-\-pinentry\fR mode \fIhttps://github\.com/gpg/pinentry\fR as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
+\fBSECRETS_PINENTRY\fR changes the \fBgpg \-\-pinentry\fR mode \fIhttps://github\.com/gpg/pinentry\fR as documented at git\-secret(7) \fIhttp://git\-secret\.io/\fR
 .
 .IP "" 0
 .

--- a/man/man1/git-secret-reveal.1.md
+++ b/man/man1/git-secret-reveal.1.md
@@ -9,9 +9,9 @@ git-secret-reveal - decrypts all added files.
 ## DESCRIPTION
 `git-secret-reveal` - decrypts all the files in `.gitsecret/paths/mapping.cfg`,
 or the passed `pathspec`s.
-You will need to have imported the paired secret-key with one of the 
+You will need to have imported the paired secret-key with one of the
 public-keys which were used in the encryption.
-Under the hood, this uses the `gpg --decrypt` command. 
+Under the hood, this uses the `gpg --decrypt` command.
 
 
 ## OPTIONS
@@ -24,8 +24,15 @@ Under the hood, this uses the `gpg --decrypt` command.
     -P  - preserve permissions of encrypted file in unencrypted file.
     -h  - shows help.
 
-(See [git-secret(7)](http://git-secret.io/git-secret) for information about renaming the .gitsecret
-folder using the SECRETS_DIR environment variable.
+
+## ENV VARIABLES
+
+- `SECRETS_GPG_COMMAND` to change the default `gpg` command to anything else
+- `SECRETS_GPG_ARMOR` boolean to enable [`--armor` mode](https://www.gnupg.org/gph/en/manual/r1290.html) to store secrets in text format over binary
+- `SECRETS_DIR` to change the default `.gitsecret/` folder to another name as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_EXTENSION` to change the default `.secret` file extension
+- `SECRETS_VERBOSE` to change the output verbosity as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_PINENTRY` to change the [`gpg --pinentry` mode](https://github.com/gpg/pinentry) as documented at [git-secret(7)](http://git-secret.io/)
 
 
 ## MANUAL
@@ -35,6 +42,6 @@ Run `man git-secret-reveal` to see this note.
 
 ## SEE ALSO
 
-[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-cat(1)](http://git-secret.io/git-secret-cat), 
-[git-secret-tell(1)](http://git-secret.io/git-secret-tell), [git-secret-add(1)](http://git-secret.io/git-secret-add), 
+[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-cat(1)](http://git-secret.io/git-secret-cat),
+[git-secret-tell(1)](http://git-secret.io/git-secret-tell), [git-secret-add(1)](http://git-secret.io/git-secret-add),
 [git-secret-hide(1)](http://git-secret.io/git-secret-hide)

--- a/man/man1/git-secret-reveal.1.md
+++ b/man/man1/git-secret-reveal.1.md
@@ -27,12 +27,12 @@ Under the hood, this uses the `gpg --decrypt` command.
 
 ## ENV VARIABLES
 
-- `SECRETS_GPG_COMMAND` to change the default `gpg` command to anything else
-- `SECRETS_GPG_ARMOR` boolean to enable [`--armor` mode](https://www.gnupg.org/gph/en/manual/r1290.html) to store secrets in text format over binary
-- `SECRETS_DIR` to change the default `.gitsecret/` folder to another name as documented at [git-secret(7)](http://git-secret.io/)
-- `SECRETS_EXTENSION` to change the default `.secret` file extension
-- `SECRETS_VERBOSE` to change the output verbosity as documented at [git-secret(7)](http://git-secret.io/)
-- `SECRETS_PINENTRY` to change the [`gpg --pinentry` mode](https://github.com/gpg/pinentry) as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_GPG_COMMAND` changes the default `gpg` command to anything else
+- `SECRETS_GPG_ARMOR` is a boolean to enable [`--armor` mode](https://www.gnupg.org/gph/en/manual/r1290.html) to store secrets in text format over binary
+- `SECRETS_DIR` changes the default `.gitsecret/` folder to another name as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_EXTENSION` changes the default `.secret` file extension
+- `SECRETS_VERBOSE` changes the output verbosity as documented at [git-secret(7)](http://git-secret.io/)
+- `SECRETS_PINENTRY` changes the [`gpg --pinentry` mode](https://github.com/gpg/pinentry) as documented at [git-secret(7)](http://git-secret.io/)
 
 
 ## MANUAL

--- a/man/man1/git-secret-tell.1
+++ b/man/man1/git-secret-tell.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-TELL" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-TELL" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-tell\fR \- adds a person, who can access private data\.
@@ -18,10 +18,10 @@ git secret tell [\-m] [\-d dir] [emails]\.\.\.
 \fBgit\-secret tell\fR receives one or more email addresses as an input, searches for the \fBgpg\fR\-key in the \fBgpg\fR \fBhomedir\fR by these emails, then imports the corresponding public key into \fBgit\-secret\fR\'s inner keychain\. From this moment this person can encrypt new files with the keyring which contains their key, but they cannot decrypt the old files, which were already encrypted without their key\. The files should be re\-encrypted with the new keyring by someone who has the unencrypted files\.
 .
 .P
-Because \fBgit\-secret tell\fR works with only email addresses, it will exit with an error if you have multiple keys in your keychain with specified email addresses, or if one of the specified emails is already associated with a key in the git\-secret keychain\.
+Because \fBgit\-secret tell\fR works with only email addresses, it will exit with an error if you have multiple keys in your keychain with specified email addresses, or if one of the specified emails is already associated with a key in the \fBgit\-secret\fR keychain\.
 .
 .P
-Versions of \fBgit\-secret tell\fR after 0\.3\.2 will warn about keys that are expired, revoked, or otherwise invalid, and also if multiple keys are found for a single email address\.
+Versions of \fBgit\-secret tell\fR after \fB0\.3\.2\fR will warn about keys that are expired, revoked, or otherwise invalid, and also if multiple keys are found for a single email address\.
 .
 .P
 \fBDo not manually import secret keys into \fBgit\-secret\fR\fR\. It won\'t work with imported secret keys anyway\.

--- a/man/man1/git-secret-tell.1.md
+++ b/man/man1/git-secret-tell.1.md
@@ -8,16 +8,16 @@ git-secret-tell - adds a person, who can access private data.
 
 ## DESCRIPTION
 `git-secret tell` receives one or more email addresses as an input, searches for the `gpg`-key in the `gpg`
-`homedir` by these emails, then imports the corresponding public key into `git-secret`'s inner keychain. 
+`homedir` by these emails, then imports the corresponding public key into `git-secret`'s inner keychain.
 From this moment this person can encrypt new files with the keyring which contains their key,
-but they cannot decrypt the old files, which were already encrypted without their key. 
+but they cannot decrypt the old files, which were already encrypted without their key.
 The files should be re-encrypted with the new keyring by someone who has the unencrypted files.
 
 Because `git-secret tell` works with only email addresses, it will exit with an error if you have
-multiple keys in your keychain with specified email addresses, or if one of the specified emails 
-is already associated with a key in the git-secret keychain.
+multiple keys in your keychain with specified email addresses, or if one of the specified emails
+is already associated with a key in the `git-secret` keychain.
 
-Versions of `git-secret tell` after 0.3.2 will warn about keys that are expired, revoked, or otherwise invalid,
+Versions of `git-secret tell` after `0.3.2` will warn about keys that are expired, revoked, or otherwise invalid,
 and also if multiple keys are found for a single email address.
 
 **Do not manually import secret keys into `git-secret`**. It won't work with imported secret keys anyway.
@@ -36,6 +36,6 @@ Run `man git-secret-tell` to see this note.
 
 ## SEE ALSO
 
-[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-add(1)](http://git-secret.io/git-secret-add), 
-[git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal), 
+[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-add(1)](http://git-secret.io/git-secret-add),
+[git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal),
 [git-secret-cat(1)](http://git-secret.io/git-secret-cat), [git-secret-removeperson(1)](http://git-secret.io/git-secret-removeperson)

--- a/man/man1/git-secret-usage.1
+++ b/man/man1/git-secret-usage.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-USAGE" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-USAGE" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-usage\fR \- prints all the available commands\.

--- a/man/man1/git-secret-usage.1.md
+++ b/man/man1/git-secret-usage.1.md
@@ -22,6 +22,6 @@ Run `man git-secret-usage` to see this note.
 
 ## SEE ALSO
 
-[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-add(1)](http://git-secret.io/git-secret-add), 
-[git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal), 
+[git-secret-init(1)](http://git-secret.io/git-secret-init), [git-secret-add(1)](http://git-secret.io/git-secret-add),
+[git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal),
 [git-secret-cat(1)](http://git-secret.io/git-secret-cat)

--- a/man/man1/git-secret-whoknows.1
+++ b/man/man1/git-secret-whoknows.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET\-WHOKNOWS" "1" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET\-WHOKNOWS" "1" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\-whoknows\fR \- prints email\-labels for each key in the keyring\.

--- a/man/man1/git-secret-whoknows.1.md
+++ b/man/man1/git-secret-whoknows.1.md
@@ -23,6 +23,6 @@ Run `man git-secret-whoknows` to see this note.
 
 ## SEE ALSO
 
-[git-secret-list(1)](http://git-secret.io/git-secret-list), [git-secret-tell(1)](http://git-secret.io/git-secret-tell), 
-[git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal), 
+[git-secret-list(1)](http://git-secret.io/git-secret-list), [git-secret-tell(1)](http://git-secret.io/git-secret-tell),
+[git-secret-hide(1)](http://git-secret.io/git-secret-hide), [git-secret-reveal(1)](http://git-secret.io/git-secret-reveal),
 [git-secret-cat(1)](http://git-secret.io/git-secret-cat)

--- a/man/man7/git-secret.7
+++ b/man/man7/git-secret.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SECRET" "7" "June 2021" "sobolevn" "git-secret 0.4.0"
+.TH "GIT\-SECRET" "7" "June 2021" "sobolevn" "git-secret 0.5.0-alpha1"
 .
 .SH "NAME"
 \fBgit\-secret\fR \- bash tool to store private data inside a git repo\.
@@ -174,33 +174,36 @@ The settings available to be changed are:
 \fB$SECRETS_GPG_COMMAND\fR \- sets the \fBgpg\fR alternatives, defaults to \fBgpg\fR\. It can be changed to \fBgpg\fR, \fBgpg2\fR, \fBpgp\fR, \fB/usr/local/gpg\fR or any other value\. After doing so rerun the tests to be sure that it won\'t break anything\. Tested to be working with: \fBgpg\fR, \fBgpg2\fR\.
 .
 .IP "\(bu" 4
+\fB$SECRETS_GPG_ARMOR\fR \- sets the \fBgpg\fR \fB\-\-armor\fR mode \fIhttps://www\.gnupg\.org/gph/en/manual/r1290\.html\fR\. Can be set to \fB1\fR to store secrets file as text\. By default is \fB0\fR and store files as binaries\.
+.
+.IP "\(bu" 4
 \fB$SECRETS_EXTENSION\fR \- sets the secret files extension, defaults to \fB\.secret\fR\. It can be changed to any valid file extension\.
 .
 .IP "\(bu" 4
-\fB$SECRETS_DIR\fR \- sets the directory where git\-secret stores its files, defaults to \.gitsecret\. It can be changed to any valid directory name\.
+\fB$SECRETS_DIR\fR \- sets the directory where \fBgit\-secret\fR stores its files, defaults to \fB\.gitsecret\fR\. It can be changed to any valid directory name\.
 .
 .IP "\(bu" 4
-\fB$SECRETS_PINENTRY\fR \- allows user to specify a setting for \fBgpg\fR\'s \-\-pinentry option\. See \fBgpg\fR docs for details about gpg\'s \-\-pinentry option\.
+\fB$SECRETS_PINENTRY\fR \- allows user to specify a setting for \fBgpg\fR\'s \fB\-\-pinentry\fR option\. See \fBgpg\fR docs \fIhttps://github\.com/gpg/pinentry\fR for details about gpg\'s \fB\-\-pinentry\fR option\.
 .
 .IP "" 0
 .
-.SH "The <code>\.gitsecret</code> folder (can be overridden with SECRETS_DIR)"
+.SH "The <code>\.gitsecret</code> folder (can be overridden with <code>SECRETS_DIR</code>)"
 This folder contains information about the files encrypted by git\-secret, and about which public/private key sets can access the encrypted data\.
 .
 .P
 You can change the name of this directory using the SECRETS_DIR environment variable\.
 .
 .P
-Use the various \'git\-secret\' commands to manipulate the files in \fB\.gitsecret\fR, you should not change the data in these files directly\.
+Use the various \fBgit\-secret\fR commands to manipulate the files in \fB\.gitsecret\fR, you should not change the data in these files directly\.
 .
 .P
-Exactly which files exist in the \fB\.gitsecret\fR folder and what their contents are vary slightly across different versions of gpg\. Thus it is best to use git\-secret with the same version of gpg being used by all users\. This can be forced using SECRETS_GPG_COMMAND environment variable\.
+Exactly which files exist in the \fB\.gitsecret\fR folder and what their contents are vary slightly across different versions of gpg\. Thus it is best to use git\-secret with the same version of gpg being used by all users\. This can be forced using \fBSECRETS_GPG_COMMAND\fR environment variable\.
 .
 .P
-Specifically, there is an issue between gpg version 2\.1\.20 and later versions which can cause problems reading and writing keyring files between systems (this shows up in errors like \'gpg: skipped packet of type 12 in keybox\')\.
+Specifically, there is an issue between \fBgpg\fR version 2\.1\.20 and later versions which can cause problems reading and writing keyring files between systems (this shows up in errors like \'gpg: skipped packet of type 12 in keybox\')\.
 .
 .P
-The git\-secret internal data is separated into two directories:
+The \fBgit\-secret\fR internal data is separated into two directories:
 .
 .SS "<code>\.gitsecret/paths</code>"
 This directory currently contains only the file \fBmapping\.cfg\fR, which lists all the files your storing encrypted\. In other words, the path mappings: what files are tracked to be hidden and revealed\.

--- a/man/man7/git-secret.7.md
+++ b/man/man7/git-secret.7.md
@@ -119,41 +119,40 @@ See below, or the man page of `git-secret` for an explanation of the environment
 
 The settings available to be changed are:
 
-* `$SECRETS_VERBOSE` - sets the verbose flag to on for all `git-secret` commands; is identical
-to using `-v` on each command that supports it.
+* `$SECRETS_VERBOSE` - sets the verbose flag to on for all `git-secret` commands; is identical to using `-v` on each command that supports it.
 
 * `$SECRETS_GPG_COMMAND` - sets the `gpg` alternatives, defaults to `gpg`.
 It can be changed to `gpg`, `gpg2`, `pgp`, `/usr/local/gpg` or any other value.
 After doing so rerun the tests to be sure that it won't break anything. Tested to be working with: `gpg`, `gpg2`.
 
+* `$SECRETS_GPG_ARMOR` - sets the `gpg` [`--armor` mode](https://www.gnupg.org/gph/en/manual/r1290.html). Can be set to `1` to store secrets file as text. By default is `0` and store files as binaries.
+
 * `$SECRETS_EXTENSION` - sets the secret files extension, defaults to `.secret`. It can be changed to any valid file extension.
 
-* `$SECRETS_DIR` - sets the directory where git-secret stores its files, defaults to .gitsecret.
-It can be changed to any valid directory name.
+* `$SECRETS_DIR` - sets the directory where `git-secret` stores its files, defaults to `.gitsecret`. It can be changed to any valid directory name.
 
-* `$SECRETS_PINENTRY` - allows user to specify a setting for `gpg`'s --pinentry option.
-See `gpg` docs for details about gpg's --pinentry option.
+* `$SECRETS_PINENTRY` - allows user to specify a setting for `gpg`'s `--pinentry` option. See [`gpg` docs](https://github.com/gpg/pinentry) for details about gpg's `--pinentry` option.
 
-## The `.gitsecret` folder (can be overridden with SECRETS_DIR)
+## The `.gitsecret` folder (can be overridden with `SECRETS_DIR`)
 
 This folder contains information about the files encrypted by git-secret,
 and about which public/private key sets can access the encrypted data.
 
 You can change the name of this directory using the SECRETS_DIR environment variable.
 
-Use the various 'git-secret' commands to manipulate the files in `.gitsecret`,
+Use the various `git-secret` commands to manipulate the files in `.gitsecret`,
 you should not change the data in these files directly.
 
 Exactly which files exist in the `.gitsecret` folder and what their contents are
 vary slightly across different versions of gpg. Thus it is best to use
 git-secret with the same version of gpg being used by all users.
-This can be forced using SECRETS_GPG_COMMAND environment variable.
+This can be forced using `SECRETS_GPG_COMMAND` environment variable.
 
-Specifically, there is an issue between gpg version 2.1.20 and later versions
+Specifically, there is an issue between `gpg` version 2.1.20 and later versions
 which can cause problems reading and writing keyring files between systems
 (this shows up in errors like 'gpg: skipped packet of type 12 in keybox').
 
-The git-secret internal data is separated into two directories:
+The `git-secret` internal data is separated into two directories:
 
 ### `.gitsecret/paths`
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -29,18 +29,6 @@ fi
 : "${SECRETS_OCTAL_PERMS_COMMAND:="_os_based __get_octal_perms"}"
 : "${SECRETS_EPOCH_TO_DATE:="_os_based __epoch_to_date"}"
 
-# _SECRETS_GPG_ARMOR is expected to be empty or '1'.
-# Empty means 'off', any other value means 'on'.
-# See: https://github.com/sobolevn/git-secret/pull/661
-# shellcheck disable=SC2153
-if [[ -n "$SECRETS_GPG_ARMOR" ]] && [[ "$SECRETS_GPG_ARMOR" -ne 0 ]]; then
-  # shellcheck disable=SC2034
-  _SECRETS_GPG_ARMOR='--armor'
-else
-  # shellcheck disable=SC2034
-  _SECRETS_GPG_ARMOR=''
-fi
-
 # Temp Dir:
 : "${TMPDIR:=/tmp}"
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -29,7 +29,18 @@ fi
 : "${SECRETS_OCTAL_PERMS_COMMAND:="_os_based __get_octal_perms"}"
 : "${SECRETS_EPOCH_TO_DATE:="_os_based __epoch_to_date"}"
 
-# Temp Dir
+# _SECRETS_GPG_ARMOR is expected to be empty or '1'.
+# Empty means 'off', any other value means 'on'.
+# See: https://github.com/sobolevn/git-secret/pull/661
+# shellcheck disable=SC2153
+if [[ -n "$SECRETS_GPG_ARMOR" ]] && [[ "$SECRETS_GPG_ARMOR" -ne 0 ]]; then
+    # shellcheck disable=SC2034
+    _SECRETS_GPG_ARMOR='--armor'
+else
+    _SECRETS_GPG_ARMOR=''
+fi
+
+# Temp Dir:
 : "${TMPDIR:=/tmp}"
 
 # AWK scripts:

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -17,8 +17,8 @@ _SECRETS_DIR_PATHS_MAPPING="${_SECRETS_DIR_PATHS}/mapping.cfg"
 # Empty means 'off', any other value means 'on'.
 # shellcheck disable=SC2153
 if [[ -n "$SECRETS_VERBOSE" ]] && [[ "$SECRETS_VERBOSE" -ne 0 ]]; then
-    # shellcheck disable=SC2034
-    _SECRETS_VERBOSE='1'
+  # shellcheck disable=SC2034
+  _SECRETS_VERBOSE='1'
 fi
 
 : "${SECRETS_EXTENSION:=".secret"}"
@@ -34,10 +34,11 @@ fi
 # See: https://github.com/sobolevn/git-secret/pull/661
 # shellcheck disable=SC2153
 if [[ -n "$SECRETS_GPG_ARMOR" ]] && [[ "$SECRETS_GPG_ARMOR" -ne 0 ]]; then
-    # shellcheck disable=SC2034
-    _SECRETS_GPG_ARMOR='--armor'
+  # shellcheck disable=SC2034
+  _SECRETS_GPG_ARMOR='--armor'
 else
-    _SECRETS_GPG_ARMOR=''
+  # shellcheck disable=SC2034
+  _SECRETS_GPG_ARMOR=''
 fi
 
 # Temp Dir:

--- a/src/commands/git_secret_add.sh
+++ b/src/commands/git_secret_add.sh
@@ -101,7 +101,7 @@ function add {
        if [[ -n "$_SECRETS_VERBOSE" ]]; then
         _message "adding file: $key"
       fi
-      
+
       ((count=count+1))
     fi
   done

--- a/src/commands/git_secret_changes.sh
+++ b/src/commands/git_secret_changes.sh
@@ -47,7 +47,7 @@ function changes {
       # Path was already normalized
       path=$(_append_root_path "$filename")
     fi
-    
+
     if [[ ! -f "$path" ]]; then
         _abort "file not found. Consider using 'git secret reveal': $filename"
     fi

--- a/src/commands/git_secret_clean.sh
+++ b/src/commands/git_secret_clean.sh
@@ -18,7 +18,7 @@ function clean {
   shift $((OPTIND-1))
   [ "$1" = '--' ] && shift
 
-  if [ $# -ne 0 ]; then 
+  if [ $# -ne 0 ]; then
     _abort "clean does not understand params: $*"
   fi
 

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -163,19 +163,24 @@ function hide {
       if [[ "$update_only_modified" -eq 0 ]] ||
          [[ "$fsdb_file_hash" != "$file_hash" ]]; then
 
-        local args=( --homedir "$secrets_dir_keys" "--no-permission-warning" --use-agent --yes "--trust-model=always" --encrypt )
+        local args=( --homedir "$secrets_dir_keys" '--no-permission-warning' --use-agent --yes '--trust-model=always' --encrypt )
 
-        if [[ ! -z "$_SECRETS_GPG_ARMOR" ]]; then
-          args+=( "$_SECRETS_GPG_ARMOR" )
+        # SECRETS_GPG_ARMOR is expected to be empty or '1'.
+        # Empty means 'off', any other value means 'on'.
+        # See: https://github.com/sobolevn/git-secret/pull/661
+        # shellcheck disable=SC2153
+        if [[ -n "$SECRETS_GPG_ARMOR" ]] &&
+           [[ "$SECRETS_GPG_ARMOR" -ne 0 ]]; then
+          args+=( '--armor' )
         fi
 
         # we depend on $recipients being split on whitespace
         # shellcheck disable=SC2206
         args+=( $recipients -o "$output_path" "$input_path" )
 
-        set +e   # disable 'set -e' so we can capture exit_code
+        set +e  # disable 'set -e' so we can capture exit_code
 
-     	  # for info about `3>&-` see:
+     	  # For info about `3>&-` see:
         # https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs
         local gpg_output
         gpg_output=$($SECRETS_GPG_COMMAND "${args[@]}" 3>&-)  # we leave stderr alone

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -162,7 +162,7 @@ function hide {
       # encrypt file only if required
       if [[ "$update_only_modified" -eq 0 ]] || [[ "$fsdb_file_hash" != "$file_hash" ]]; then
 
-        local args=( --homedir "$secrets_dir_keys" "--no-permission-warning" --use-agent --yes "--trust-model=always" --encrypt )
+        local args=( --homedir "$secrets_dir_keys" "--no-permission-warning" --use-agent --yes "--trust-model=always" --encrypt --armor )
 
         # we depend on $recipients being split on whitespace
         # shellcheck disable=SC2206

--- a/src/commands/git_secret_init.sh
+++ b/src/commands/git_secret_init.sh
@@ -53,7 +53,7 @@ function init {
   shift $((OPTIND-1))
   [ "$1" = '--' ] && shift
 
-  if [ $# -ne 0 ]; then 
+  if [ $# -ne 0 ]; then
     _abort "init does not understand params: $*"
   fi
 

--- a/src/commands/git_secret_list.sh
+++ b/src/commands/git_secret_list.sh
@@ -15,7 +15,7 @@ function list {
   shift $((OPTIND-1))
   [ "$1" = '--' ] && shift
 
-  if [ $# -ne 0 ]; then 
+  if [ $# -ne 0 ]; then
     _abort "list does not understand params: $*"
   fi
 

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -76,7 +76,7 @@ function reveal {
         chmod "$perms" "$path"
       fi
     fi
-  
+
   done
 
   _message "done. $counter of ${#to_show[@]} files are revealed."

--- a/src/commands/git_secret_whoknows.sh
+++ b/src/commands/git_secret_whoknows.sh
@@ -18,7 +18,7 @@ function whoknows {
   shift $((OPTIND-1))
   [ "$1" = "--" ] && shift
 
-  if [ $# -ne 0 ]; then 
+  if [ $# -ne 0 ]; then
     _abort "whoknows does not understand params: $*"
   fi
 

--- a/src/version.sh
+++ b/src/version.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=2034
-GITSECRET_VERSION='0.4.1-alpha1'
+GITSECRET_VERSION='0.5.0-alpha1'

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -274,7 +274,8 @@ function set_state_secret_add_without_newline {
 
 
 function set_state_secret_hide {
-  git secret hide >> "$TEST_GPG_OUTPUT_FILE" 2>&1
+  local armor="$1"
+  SECRETS_GPG_ARMOR="$armor" git secret hide >> "$TEST_GPG_OUTPUT_FILE" 2>&1
 }
 
 

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -35,7 +35,33 @@ function teardown {
   [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # New file must be created:
-  [ -f "$(_get_encrypted_filename "$FILE_TO_HIDE")" ]
+  local new_file
+  new_file="$(_get_encrypted_filename "$FILE_TO_HIDE")"
+  [ -f "$new_file" ]
+
+  # File must be a binary:
+  local mime
+  mime="$(file --mime-type --mime-encoding "$new_file" | grep 'charset=binary')"
+  [ ! -z "$mime" ]
+}
+
+
+@test "run 'hide' with SECRETS_GPG_ARMOR=1" {
+  SECRETS_GPG_ARMOR=1 run git secret hide
+
+  # Command must execute normally:
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
+
+  # New file must be created:
+  local new_file
+  new_file="$(_get_encrypted_filename "$FILE_TO_HIDE")"
+  [ -f "$new_file" ]
+
+  # File must be a text:
+  local mime
+  mime="$(file --mime-type --mime-encoding "$new_file" | grep 'charset=us-ascii')"
+  [ ! -z "$mime" ]
 }
 
 

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -73,6 +73,36 @@ function teardown {
 }
 
 
+@test "run 'reveal' binary with 'SECRETS_GPG_ARMOR=1'" {
+  rm "$FILE_TO_HIDE"
+
+  local password=$(test_user_password "$TEST_DEFAULT_USER")
+  # Armor should not change anything here:
+  SECRETS_GPG_ARMOR=1 run git secret reveal -d "$TEST_GPG_HOMEDIR" -p "$password"
+
+  [ "$status" -eq 0 ]
+  [ -f "$FILE_TO_HIDE" ]
+}
+
+
+@test "run 'reveal' armored with 'SECRETS_GPG_ARMOR=1'" {
+  # We need to clean existing binary files:
+  git secret clean
+
+  # Now, let's hide files once again with `--armor` enabled:
+  set_state_secret_hide '1'
+
+  rm "$FILE_TO_HIDE"
+
+  local password=$(test_user_password "$TEST_DEFAULT_USER")
+  # Armor should not change anything here:
+  SECRETS_GPG_ARMOR=1 run git secret reveal -d "$TEST_GPG_HOMEDIR" -p "$password"
+
+  [ "$status" -eq 0 ]
+  [ -f "$FILE_TO_HIDE" ]
+}
+
+
 @test "run 'reveal' with '-v'" {
   rm "$FILE_TO_HIDE"
 

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -103,6 +103,24 @@ function teardown {
 }
 
 
+@test "run 'reveal' armored with 'SECRETS_GPG_ARMOR=0'" {
+  # We need to clean existing binary files:
+  git secret clean
+
+  # Now, let's hide files once again with `--armor` enabled:
+  set_state_secret_hide '1'
+
+  rm "$FILE_TO_HIDE"
+
+  local password=$(test_user_password "$TEST_DEFAULT_USER")
+  # Armor should not change anything here:
+  SECRETS_GPG_ARMOR=0 run git secret reveal -d "$TEST_GPG_HOMEDIR" -p "$password"
+
+  [ "$status" -eq 0 ]
+  [ -f "$FILE_TO_HIDE" ]
+}
+
+
 @test "run 'reveal' with '-v'" {
   rm "$FILE_TO_HIDE"
 


### PR DESCRIPTION
Recreation of #632 
For #631 

Use gpg --armor when encrypting/hiding files, so secret files are text instead of binary.

When testing with gpg 2.0.22 and git-secret master, I found that I could 'reveal' files encrypted whether or not they had been hidden with the --armor option.

This needs to be tested with older and newer versions of gpg, also to make sure armored files encrypted with 2.2 are decryptable with ancient gnupg versions.