### PR TITLE
fix missing hyphens in some of the git-secret command mentions

### DIFF
--- a/man/man7/git-secret.7.md
+++ b/man/man7/git-secret.7.md
@@ -7,7 +7,7 @@ These steps cover the basic process of using `git-secret`:
 
 0. Before starting, [make sure you have created a `gpg` RSA key-pair](#using-gpg): a public and a secret key identified by your email address.
 
-1. Begin with an existing or new git repository. You'll use the 'git secret' commands to add the keyrings and information
+1. Begin with an existing or new git repository. You'll use the 'git-secret' commands to add the keyrings and information
 to make `git-secret` hide and reveal files in this repository.
 
 2. Initialize the `git-secret` repository by running `git secret init` command. The `.gitsecret/` folder will be created.
@@ -141,7 +141,7 @@ and about which public/private key sets can access the encrypted data.
 
 You can change the name of this directory using the SECRETS_DIR environment variable.
 
-Use the various 'git secret' commands to manipulate the files in `.gitsecret`,
+Use the various 'git-secret' commands to manipulate the files in `.gitsecret`,
 you should not change the data in these files directly.
 
 Exactly which files exist in the `.gitsecret` folder and what their contents are

--- a/tests/test_main.bats
+++ b/tests/test_main.bats
@@ -14,29 +14,29 @@ function teardown {
 }
 
 
-@test "run 'git-secret' without command" {
-  run git-secret
+@test "run 'git secret' without command" {
+  run git secret
   [ "$status" -eq 126 ]
 }
 
 
-@test "run 'git-secret' with bad command" {
-  run git-secret notacommand
+@test "run 'git secret' with bad command" {
+  run git secret notacommand
   [ "$status" -eq 126 ]
 }
 
 
-@test "run 'git-secret --version'" {
-  run git-secret --version
+@test "run 'git secret --version'" {
+  run git secret --version
   [ "$output" == "$GITSECRET_VERSION" ]
 }
 
 
-@test "run 'git-secret --dry-run'" {
+@test "run 'git secret --dry-run'" {
   # We will break things apart, so normally it won't run:
   rm -r "./.git"
 
-  # test of 'git-secret usage' here removed as it's duplicated in test_usage.bats
+  # test of 'git secret usage' here removed as it's duplicated in test_usage.bats
 
   # Dry run won't fail:
   run git secret --dry-run

--- a/tests/test_main.bats
+++ b/tests/test_main.bats
@@ -14,29 +14,29 @@ function teardown {
 }
 
 
-@test "run 'git secret' without command" {
-  run git secret
+@test "run 'git-secret' without command" {
+  run git-secret
   [ "$status" -eq 126 ]
 }
 
 
-@test "run 'git secret' with bad command" {
-  run git secret notacommand
+@test "run 'git-secret' with bad command" {
+  run git-secret notacommand
   [ "$status" -eq 126 ]
 }
 
 
-@test "run 'git secret --version'" {
-  run git secret --version
+@test "run 'git-secret --version'" {
+  run git-secret --version
   [ "$output" == "$GITSECRET_VERSION" ]
 }
 
 
-@test "run 'git secret --dry-run'" {
+@test "run 'git-secret --dry-run'" {
   # We will break things apart, so normally it won't run:
   rm -r "./.git"
 
-  # test of 'git secret usage' here removed as it's duplicated in test_usage.bats
+  # test of 'git-secret usage' here removed as it's duplicated in test_usage.bats
 
   # Dry run won't fail:
   run git secret --dry-run


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes wrong mentions of `git-secret` as `git secret`.


Does this close any currently open issues?
------------------------------------------
Fixes issue: https://github.com/sobolevn/git-secret/issues/655

Depends on CI for tests
Didn't add anything to change logs as it's all documentation changes.
