### PR TITLE
bump version to 0.4.1-alpha1

### DIFF
--- a/src/version.sh
+++ b/src/version.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=2034
-GITSECRET_VERSION='0.4.0'
+GITSECRET_VERSION='0.4.1-alpha1'


### PR DESCRIPTION
bump version to 0.4.1-alpha1, so there are fewer versions of 0.4.0 floating around