### PR TITLE
Support spaces in shell path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL:=bash
 PREFIX?="/usr"
 DESTDIR?=
 
@@ -21,11 +22,11 @@ build:
 
 .PHONY: install
 install:
-	bash ./utils/install.sh "${DESTDIR}${PREFIX}"
+	"${SHELL}" ./utils/install.sh "${DESTDIR}${PREFIX}"
 
 .PHONY: uninstall
 uninstall:
-	bash ./utils/uninstall.sh "${DESTDIR}${PREFIX}"
+	"${SHELL}" ./utils/uninstall.sh "${DESTDIR}${PREFIX}"
 
 #
 # Testing and linting:
@@ -38,7 +39,7 @@ uninstall:
 test: clean build
 	export SECRETS_PROJECT_ROOT="$(shell echo $${PWD})"; \
 	export PATH="$(shell echo $${PWD})/vendor/bats-core/bin:$(shell echo $${PWD}):$(shell echo $${PATH})"; \
-	bash ./utils/tests.sh
+	"${SHELL}" ./utils/tests.sh
 
 # We use this script in CI and you can do this too!
 # What happens here?
@@ -105,7 +106,7 @@ build-man: build
 
 .PHONY: build-docs
 build-docs: build-man
-	 bash docs/build.sh
+	 "${SHELL}" docs/build.sh
 
 .PHONY: docs
 docs: build-docs


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

On Windows with MINGW64 the `${SHELL}` command can become `C:/Program Files/Git/usr/local` so it must be put in quotation marks to support the space character in "Program Files".

Does this close any currently open issues?
------------------------------------------

Yes: https://github.com/sobolevn/git-secret/issues/722