### PR TITLE
Add Windows docker image to run tests on CI environment

### DIFF
--- a/.ci/docker-ci/windows/Dockerfile
+++ b/.ci/docker-ci/windows/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/windows:20H2
+
+RUN gcc --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           - alpine
           - fedora
           - centos
+          - windows
     steps:
     - uses: actions/checkout@v2
     - name: Run checks


### PR DESCRIPTION
This is a draft PR and subject to change. It's an attempt to add Windows to the testing matrix: https://github.com/sobolevn/git-secret/issues/722#issuecomment-944447938