### PR TITLE
fix for #710, using cat from a subdir

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -378,6 +378,22 @@ function _append_root_path {
 }
 
 
+function _append_relative_root_path {
+  local path="$1" # required
+
+  local root_path
+  root_path=$(_append_root_path "$path")
+    
+  # For #710: if we are in a subdir, fixup the path with the subdir
+  local subdir
+  subdir=$(git rev-parse --show-prefix)   # get the subdir of repo, like "subdir/"
+  if [ ! -z "$subdir" ]; then
+    root_path="$(dirname $root_path)/${subdir}/$(basename $root_path)" 
+  fi
+
+  echo "$root_path"
+}
+
 function _get_secrets_dir {
   _append_root_path "${_SECRETS_DIR}"
 }

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -378,20 +378,21 @@ function _append_root_path {
 }
 
 
+# if passed a name like 'filename.txt', returns a full path in the repo
+# For #710: if we are in a subdir, fixup the path with the subdir
 function _append_relative_root_path {
   local path="$1" # required
 
-  local root_path
-  root_path=$(_append_root_path "$path")
+  local full_path
+  full_path=$(_append_root_path "$path")
     
-  # For #710: if we are in a subdir, fixup the path with the subdir
   local subdir
   subdir=$(git rev-parse --show-prefix)   # get the subdir of repo, like "subdir/"
   if [ ! -z "$subdir" ]; then
-    root_path="$(dirname $root_path)/${subdir}/$(basename $root_path)" 
+    full_path="$(dirname $full_path)/${subdir}/$(basename $full_path)" 
   fi
 
-  echo "$root_path"
+  echo "$full_path"
 }
 
 function _get_secrets_dir {

--- a/src/commands/git_secret_cat.sh
+++ b/src/commands/git_secret_cat.sh
@@ -32,19 +32,7 @@ function cat {
     local path
 
     filename=$(_get_record_filename "$line")
-    path=$(_append_root_path "$filename")
-
-    # now check if we're in a subdir of the repo, for #710
-    # NOTE TO SELF: if we are in a subdir, reconstruct the path with the subdir in it.
-    # note that this means the dir from _append_root_path is wrong, 
-    # but if you fix it there other things break. 
-    # Probably we should use this in a new function like _append_relative_root_path() (name?)
-    local subdir
-    subdir=$(git rev-parse --show-prefix)   # get the subdir of repo, like "subdir/"
-    if [ ! -z "$subdir" ]; then
-      path="$(dirname $path)/${subdir}/$(basename $path)" 
-    fi
-
+    path=$(_append_relative_root_path "$filename")  # this uses the _relative version because of #710
     # The parameters are: filename, write-to-file, force, homedir, passphrase
     _decrypt "$path" "0" "0" "$homedir" "$passphrase"
   done

--- a/src/commands/git_secret_cat.sh
+++ b/src/commands/git_secret_cat.sh
@@ -34,6 +34,17 @@ function cat {
     filename=$(_get_record_filename "$line")
     path=$(_append_root_path "$filename")
 
+    # now check if we're in a subdir of the repo, for #710
+    # NOTE TO SELF: if we are in a subdir, reconstruct the path with the subdir in it.
+    # note that this means the dir from _append_root_path is wrong, 
+    # but if you fix it there other things break. 
+    # Probably we should use this in a new function like _append_relative_root_path() (name?)
+    local subdir
+    subdir=$(git rev-parse --show-prefix)   # get the subdir of repo, like "subdir/"
+    if [ ! -z "$subdir" ]; then
+      path="$(dirname $path)/${subdir}/$(basename $path)" 
+    fi
+
     # The parameters are: filename, write-to-file, force, homedir, passphrase
     _decrypt "$path" "0" "0" "$homedir" "$passphrase"
   done

--- a/src/commands/git_secret_cat.sh
+++ b/src/commands/git_secret_cat.sh
@@ -33,6 +33,7 @@ function cat {
 
     filename=$(_get_record_filename "$line")
     path=$(_append_relative_root_path "$filename")  # this uses the _relative version because of #710
+
     # The parameters are: filename, write-to-file, force, homedir, passphrase
     _decrypt "$path" "0" "0" "$homedir" "$passphrase"
   done

--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -55,7 +55,7 @@ function reveal {
     local filename
     local path
     filename=$(_get_record_filename "$line")
-    path=$(_append_root_path "$filename")
+    path=$(_append_relative_root_path "$filename")  # this uses the _relative version because of #710
 
     if [[ "$filename" == *"$SECRETS_EXTENSION" ]]; then
       _abort "cannot decrypt to secret version of file: $filename"

--- a/tests/test_cat.bats
+++ b/tests/test_cat.bats
@@ -74,6 +74,6 @@ function teardown {
   [ "$status" -eq 0 ]
   run git secret hide
   [ "$status" -eq 0 ]
-  run git secret cat -d "$TEST_GPG_HOMEDIR" -p "$password" filename.txt
+  run git secret cat -d "$TEST_GPG_HOMEDIR" -p "$password" new_filename.txt
   [ "$status" -eq 0 ]
 }

--- a/tests/test_cat.bats
+++ b/tests/test_cat.bats
@@ -63,3 +63,14 @@ function teardown {
   run git secret cat -Z -d "$TEST_GPG_HOMEDIR" -p "$password" "$FILE_TO_HIDE"
   [ "$status" -ne 0 ]
 }
+
+@test "run 'cat' from subdir" {
+  local password
+  password=$(test_user_password "$TEST_DEFAULT_USER")
+  mkdir subdir
+  echo "content2" > subdir/new_filename.txt
+  cd subdir
+  run git secret add new_filename.txt
+  run git secret hide
+  run git secret cat -d "$TEST_GPG_HOMEDIR" -p "$password" filename.txt
+}

--- a/tests/test_cat.bats
+++ b/tests/test_cat.bats
@@ -67,19 +67,20 @@ function teardown {
 @test "run 'cat' from subdir" {
   local password
   password=$(test_user_password "$TEST_DEFAULT_USER")
+
   mkdir subdir
   echo "content2" > subdir/new_filename.txt
+
   cd subdir
   run git secret add new_filename.txt
   [ "$status" -eq 0 ]
   run git secret hide
   [ "$status" -eq 0 ]
 
-  # try it with -d and -p
   run git secret cat -d "$TEST_GPG_HOMEDIR" -p "$password" new_filename.txt
   [ "$status" -eq 0 ]
 
-  # try it without -d and -p
-  git secret cat new_filename.txt
-  [ "$status" -eq 0 ]
+  # clean up
+  cd ..
+  rm -rf subdir
 }

--- a/tests/test_cat.bats
+++ b/tests/test_cat.bats
@@ -80,6 +80,6 @@ function teardown {
   [ "$status" -eq 0 ]
 
   # try it without -d and -p
-  run bash -x git secret cat new_filename.txt
+  git secret cat new_filename.txt
   [ "$status" -eq 0 ]
 }

--- a/tests/test_cat.bats
+++ b/tests/test_cat.bats
@@ -71,6 +71,9 @@ function teardown {
   echo "content2" > subdir/new_filename.txt
   cd subdir
   run git secret add new_filename.txt
+  [ "$status" -eq 0 ]
   run git secret hide
+  [ "$status" -eq 0 ]
   run git secret cat -d "$TEST_GPG_HOMEDIR" -p "$password" filename.txt
+  [ "$status" -eq 0 ]
 }

--- a/tests/test_cat.bats
+++ b/tests/test_cat.bats
@@ -74,6 +74,12 @@ function teardown {
   [ "$status" -eq 0 ]
   run git secret hide
   [ "$status" -eq 0 ]
+
+  # try it with -d and -p
   run git secret cat -d "$TEST_GPG_HOMEDIR" -p "$password" new_filename.txt
+  [ "$status" -eq 0 ]
+
+  # try it without -d and -p
+  run bash -x git secret cat new_filename.txt
   [ "$status" -eq 0 ]
 }

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -270,3 +270,24 @@ function teardown {
     -p "$password"
   [ "$status" -ne 0 ]
 }
+
+@test "run 'reveal' with named file from subdir" {
+  local password
+  password=$(test_user_password "$TEST_DEFAULT_USER")
+
+  mkdir subdir
+  echo "content2" > subdir/new_filename.txt
+
+  cd subdir
+  run git secret add new_filename.txt
+  [ "$status" -eq 0 ]
+  run git secret hide
+  [ "$status" -eq 0 ]
+
+  run git secret reveal -d "$TEST_GPG_HOMEDIR" -p "$password" new_filename.txt
+  [ "$status" -eq 0 ]
+
+  # clean up
+  cd ..
+  rm -rf subdir
+}


### PR DESCRIPTION
Closes #710

Fixes 'git secret cat filename.txt' and 'git secret reveal filename.txt' when used from a subdirectory of the repo.