### PR TITLE
Issue 675 update doc to use gpg in GitHub actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Rename `killperson` command to `removeperson` (#684)
 - Moves `file_has_line` utility to tests and fixes how it is used
-- Refactors docs: new pages, new content
+- Refactors docs: new pages, new content (#675)
 
 
 ## 0.4.0

--- a/man/man7/git-secret.7.md
+++ b/man/man7/git-secret.7.md
@@ -90,12 +90,12 @@ if your app is called MyApp and your CI/CD provider is CodeShip. It is easier no
 # see: https://git-secret.io/installation
 
 # Create private key file
-echo $GPG_PRIVATE_KEY > ./private_key.gpg
+echo "$GPG_PRIVATE_KEY" > ./private_key.gpg
 # Import private key and avoid the "Inappropriate ioctl for device" error
 gpg --batch --yes --pinentry-mode loopback --import private_key.gpg
 # Reveal secrets without user interaction and with passphrase. If no passphrase
 # is created for the key, remove `-p $GPG_PASSPHRASE`
-git secret reveal -p $GPG_PASSPHRASE
+git secret reveal -p "$GPG_PASSPHRASE"
 # carry on with your build script, secret files are available ...
 ```
 
@@ -108,7 +108,7 @@ gpg --armor --export-secret-key myapp@codeship.com | tr '\n' ','
 You can then create your private key file with:
 
 ```shell
-echo $GPG_PRIVATE_KEY | tr ',' '\n' > ./private_key.gpg
+echo "$GPG_PRIVATE_KEY" | tr ',' '\n' > ./private_key.gpg
 ```
 
 Also note: the `gpg` version on the CI/CD server **MUST MATCH** the one used locally. Otherwise, `gpg` decryption can fail silently, which leads to `git secret reveal` reporting `cannot find decrypted version of file` error. To be specific, `apt-get install gnupg` points to version [2.2.20](https://packages.ubuntu.com/impish/gnupg), yet `brew install gnupg` points to version [2.3.4](https://formulae.brew.sh/formula/gnupg) (as of 2022-01-17). Thus a `git-secret` encrypted file on macOS using the latest `gpg` installed from `brew` cannot be decrypted on Ubuntu (e.g. GitHub Actions' latest Ubuntu machine) using the latest `gpg` installed from `apt-get`. The work-around for this specific case is to downgrade `gpg` with `brew install gnupg@2.2.33`.

--- a/man/man7/git-secret.7.md
+++ b/man/man7/git-secret.7.md
@@ -80,9 +80,9 @@ with the changes in your code.
 One way of doing it is the following:
 
 1. [create a gpg key](#using-gpg) for your CI/CD environment. You can chose any name and email address you want: for instance `MyApp CodeShip <myapp@codeship.com>`
-if your app is called MyApp and your CI/CD provider is CodeShip. It is easier not to define a password for that key.
+if your app is called MyApp and your CI/CD provider is CodeShip. It is easier not to define a passphrase for that key. However, if defining a passphrase is unavoidable, use a unique passphrase for the private key.
 2. run `gpg --armor --export-secret-key myapp@codeship.com` to get your private key value
-3. Create an env var on your CI/CD server `GPG_PRIVATE_KEY` and assign it the private key value.
+3. Create an env var on your CI/CD server `GPG_PRIVATE_KEY` and assign it the private key value. If a passphrase has been setup for the private key, create another env var on the CI/CD server `GPG_PASSPHRASE` and assign it the passphrase of the private key.
 4. Then write your Continuous Deployment build script. For instance:
 
 ```shell
@@ -91,10 +91,11 @@ if your app is called MyApp and your CI/CD provider is CodeShip. It is easier no
 
 # Create private key file
 echo $GPG_PRIVATE_KEY > ./private_key.gpg
-# Import private key
-gpg --import ./private_key.gpg
-# Reveal secrets
-git secret reveal
+# Import private key and avoid the "Inappropriate ioctl for device" error
+gpg --batch --yes --pinentry-mode loopback --import private_key.gpg
+# Reveal secrets without user interaction and with passphrase. If no passphrase
+# is created for the key, remove `-p $GPG_PASSPHRASE`
+git secret reveal -p $GPG_PASSPHRASE
 # carry on with your build script, secret files are available ...
 ```
 
@@ -109,6 +110,9 @@ You can then create your private key file with:
 ```shell
 echo $GPG_PRIVATE_KEY | tr ',' '\n' > ./private_key.gpg
 ```
+
+Also note: the `gpg` version on the CI/CD server **MUST MATCH** the one used locally. Otherwise, `gpg` decryption can fail silently, which leads to `git secret reveal` reporting `cannot find decrypted version of file` error. To be specific, `apt-get install gnupg` points to version [2.2.20](https://packages.ubuntu.com/impish/gnupg), yet `brew install gnupg` points to version [2.3.4](https://formulae.brew.sh/formula/gnupg) (as of 2022-01-17). Thus a `git-secret` encrypted file on macOS using the latest `gpg` installed from `brew` cannot be decrypted on Ubuntu (e.g. GitHub Actions' latest Ubuntu machine) using the latest `gpg` installed from `apt-get`. The work-around for this specific case is to downgrade `gpg` with `brew install gnupg@2.2.33`.
+
 
 ## Environment Variables and Configuration
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .md file(s) in man/man*/ to document your changes if appropriate
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Update the man page regarding the usage of `git-secret` with CI/CD server. In particular, fix the error about how a private key shall be imported without triggering error (see #675)

Also, a caution is added regarding failure of decryption if the `gpg` version used on the CI/CD server does not match that used locally (i.e. the one used to encrypt the file).

Does this close any currently open issues?
------------------------------------------
Yes, it closes #675 

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…
