### PR TITLE
in verbose mode, show some gnupg perm warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Update docs for use with CI/CD server (#675)
 - Test, and build RPMS, with Rocky and Alma Linux instead of CentOS (#765)
 - Improve testing of .gitignore contents (#792)
+- Automate running verbose tests with SECRETS_TEST_VERBOSE=1 (#794)
 
 
 ## 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adds `SECRETS_GPG_ARMOR` env variable to use `gpg --armor`
   when encrypting files, so secret files are stored
   in text format rather than binary (#631)
+- Do not suppress permission warnings from gnupg in verbose mode (#811)
 
 ### Bugfixes
 
@@ -18,7 +19,6 @@
 ### Misc
 
 - Rename `killperson` command to `removeperson` (#684)
-- Moves `file_has_line` utility to tests and fixes how it is used
 - Refactor docs: new pages, new content 
 - Upgrade bats-core to v1.6.0 (#755)
 - Update docs for use with CI/CD server (#675)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   when encrypting files, so secret files are stored
   in text format rather than binary (#631)
 - Do not suppress permission warnings from gnupg in verbose mode (#811)
+- `git secret init` now sets `.gitsecret/keys` permission to 0700 (#811)
 
 ### Bugfixes
 

--- a/man/man1/git-secret-init.1.md
+++ b/man/man1/git-secret-init.1.md
@@ -11,9 +11,14 @@ git-secret-init - initializes git-secret repository.
 Until repository is initialized with `git secret init`, all other `git-secret` commands are unavailable.
 
 If a `.gitsecret` directory already exists, `git-secret-init` exits without making any changes.
-Otherwise, a .gitsecret directory is created with appropriate sub-directories,
-and patterns to ignore `git-secret`'s `random_seed_file`
-and not ignore `.secret` files are added to `.gitignore`.
+Otherwise, 
+
+* `.gitignore` is modified to ignore `git-secret`'s `random_seed_file`,
+and to not ignore `.secret` files,
+
+* a .gitsecret directory is created with the sub-directories /keys and /paths,
+
+* The `.gitsecret/keys` subdirectory permissions are set to 700 to make gnupg happy.
 
 (See [git-secret(7)](https://git-secret.io/git-secret) for information about renaming the .gitsecret
 folder with the `SECRETS_DIR` environment variable, and changing the extension `git-secret` uses for secret files

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -13,22 +13,6 @@ _SECRETS_DIR_KEYS_TRUSTDB="${_SECRETS_DIR_KEYS}/trustdb.gpg"
 
 _SECRETS_DIR_PATHS_MAPPING="${_SECRETS_DIR_PATHS}/mapping.cfg"
 
-# returns 0 for true, 1 for false (really)
-function is_git_version_ge_2_28_0() { # based on code from github autopilot
-    # shellcheck disable=SC2155
-    local git_version=$(git --version | awk '{print $3}')
-    # shellcheck disable=SC2155
-    local git_version_major=$(echo "$git_version" | awk -F. '{print $1}')
-    # shellcheck disable=SC2155
-    local git_version_minor=$(echo "$git_version" | awk -F. '{print $2}')
-    # shellcheck disable=SC2155
-    local git_version_patch=$(echo "$git_version" | awk -F. '{print $3}')
-    if [[ $git_version_major -ge 2 ]] && [[ $git_version_minor -ge 28 ]] && [[ $git_version_patch -ge 0 ]]; then
-        return 0
-    else
-        return 1
-    fi
-}
 
 # shellcheck disable=SC2153
 if [[ -n "$SECRETS_VERBOSE" ]] && [[ "$SECRETS_VERBOSE" -ne 0 ]]; then

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -25,12 +25,12 @@ function is_git_version_ge_2_28_0() { # based on code from github autopilot
     fi
 }
 
-# _SECRETS_VERBOSE is expected to be empty or '1'. 
-# Empty means 'off', any other value means 'on'.
 # shellcheck disable=SC2153
 if [[ -n "$SECRETS_VERBOSE" ]] && [[ "$SECRETS_VERBOSE" -ne 0 ]]; then
   # shellcheck disable=SC2034
   _SECRETS_VERBOSE='1'
+  # _SECRETS_VERBOSE is empty or '1'. 
+  # Empty means 'off', any other value means 'on'.
 fi
 
 : "${SECRETS_EXTENSION:=".secret"}"

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -13,6 +13,7 @@ _SECRETS_DIR_KEYS_TRUSTDB="${_SECRETS_DIR_KEYS}/trustdb.gpg"
 
 _SECRETS_DIR_PATHS_MAPPING="${_SECRETS_DIR_PATHS}/mapping.cfg"
 
+# returns 0 for true, 1 for false (really)
 function is_git_version_ge_2_28_0() { # based on code from github autopilot
     # shellcheck disable=SC2155
     local git_version=$(git --version | awk '{print $3}')

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -13,7 +13,19 @@ _SECRETS_DIR_KEYS_TRUSTDB="${_SECRETS_DIR_KEYS}/trustdb.gpg"
 
 _SECRETS_DIR_PATHS_MAPPING="${_SECRETS_DIR_PATHS}/mapping.cfg"
 
-# _SECRETS_VERBOSE is expected to be empty or '1'.
+function is_git_version_ge_2_28_0() { # based on code from github autopilot
+    local git_version=$(git --version | awk '{print $3}')
+    local git_version_major=$(echo $git_version | awk -F. '{print $1}')
+    local git_version_minor=$(echo $git_version | awk -F. '{print $2}')
+    local git_version_patch=$(echo $git_version | awk -F. '{print $3}')
+    if [[ $git_version_major -ge 2 ]] && [[ $git_version_minor -ge 28 ]] && [[ $git_version_patch -ge 0 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# _SECRETS_VERBOSE is expected to be empty or '1'. 
 # Empty means 'off', any other value means 'on'.
 # shellcheck disable=SC2153
 if [[ -n "$SECRETS_VERBOSE" ]] && [[ "$SECRETS_VERBOSE" -ne 0 ]]; then

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -14,10 +14,14 @@ _SECRETS_DIR_KEYS_TRUSTDB="${_SECRETS_DIR_KEYS}/trustdb.gpg"
 _SECRETS_DIR_PATHS_MAPPING="${_SECRETS_DIR_PATHS}/mapping.cfg"
 
 function is_git_version_ge_2_28_0() { # based on code from github autopilot
+    # shellcheck disable=SC2155
     local git_version=$(git --version | awk '{print $3}')
-    local git_version_major=$(echo $git_version | awk -F. '{print $1}')
-    local git_version_minor=$(echo $git_version | awk -F. '{print $2}')
-    local git_version_patch=$(echo $git_version | awk -F. '{print $3}')
+    # shellcheck disable=SC2155
+    local git_version_major=$(echo "$git_version" | awk -F. '{print $1}')
+    # shellcheck disable=SC2155
+    local git_version_minor=$(echo "$git_version" | awk -F. '{print $2}')
+    # shellcheck disable=SC2155
+    local git_version_patch=$(echo "$git_version" | awk -F. '{print $3}')
     if [[ $git_version_major -ge 2 ]] && [[ $git_version_minor -ge 28 ]] && [[ $git_version_patch -ge 0 ]]; then
         return 0
     else

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -782,7 +782,7 @@ function _decrypt {
   local encrypted_filename
   encrypted_filename=$(_get_encrypted_filename "$filename")
 
-  local args=( "--use-agent" "--decrypt" "--no-permission-warning" )
+  local args=( "--use-agent" "--decrypt" )
 
   if [[ "$write_to_file" -eq 1 ]]; then
     args+=( "-o" "$filename" )
@@ -806,6 +806,8 @@ function _decrypt {
 
   if [[ -z "$_SECRETS_VERBOSE" ]]; then
     args+=( "--quiet" )
+  else
+    args+=( "--no-permission-warning" )
   fi
 
   set +e   # disable 'set -e' so we can capture exit_code

--- a/src/commands/git_secret_add.sh
+++ b/src/commands/git_secret_add.sh
@@ -2,12 +2,11 @@
 
 
 function add {
-  local auto_ignore=1
   OPTIND=1
 
   while getopts "ihv" opt; do
     case "$opt" in
-      i) auto_ignore=1;;    # this doesn't change anything
+      i) ;;    # this doesn't change anything
 
       h) _show_manual_for "add";;
 
@@ -59,26 +58,14 @@ function add {
   # Are there any unignored files?
 
   if [[ ! "${#not_ignored[@]}" -eq 0 ]]; then
-    # And show them all at once.
-    local message
-    message="these files are not in .gitignore: ${not_ignored[*]}"
-    # NOTE: message has spaces between filenames, which can be ambiguous if files also have spaces
+    # Add these files to `.gitignore` automatically:
+    # see https://github.com/sobolevn/git-secret/issues/18 for more.
 
-    if [[ "$auto_ignore" -eq 0 ]]; then
-      # This file is not ignored. user don't want it to be added automatically.
-      # Raise the exception, since all files, which will be hidden, must be ignored.
-      # note that it is no longer possible to wind up in this code path as auto_ignore cannot be 0.
-      # code left here in case we want to restore/modify this path later
-      _abort "$message"
-    else
-      # In this case these files should be added to the `.gitignore` automatically:
-      # see https://github.com/sobolevn/git-secret/issues/18 for more.
-      _message "$message"
-      _message "auto adding them to .gitignore"
-      for item in "${not_ignored[@]}"; do
-        _add_ignored_file "$item"
-      done
-    fi
+    # NOTE: output has spaces between filenames, which can be ambiguous if files also have spaces
+    _message "files not in .gitignore, adding: ${not_ignored[*]}"
+    for item in "${not_ignored[@]}"; do
+      _add_ignored_file "$item"
+    done
   fi
 
   # Adding files to path mappings:

--- a/src/commands/git_secret_add.sh
+++ b/src/commands/git_secret_add.sh
@@ -61,9 +61,8 @@ function add {
     # Add these files to `.gitignore` automatically:
     # see https://github.com/sobolevn/git-secret/issues/18 for more.
 
-    # NOTE: output has spaces between filenames, which can be ambiguous if files also have spaces
-    _message "files not in .gitignore, adding: ${not_ignored[*]}"
     for item in "${not_ignored[@]}"; do
+      _message "file not in .gitignore, adding: $item"
       _add_ignored_file "$item"
     done
   fi

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -163,7 +163,7 @@ function hide {
       if [[ "$update_only_modified" -eq 0 ]] ||
          [[ "$fsdb_file_hash" != "$file_hash" ]]; then
 
-        local args=( --homedir "$secrets_dir_keys" '--no-permission-warning' --use-agent --yes '--trust-model=always' --encrypt )
+        local args=( --homedir "$secrets_dir_keys" --use-agent --yes '--trust-model=always' --encrypt )
 
         # SECRETS_GPG_ARMOR is expected to be empty or '1'.
         # Empty means 'off', any other value means 'on'.
@@ -172,6 +172,10 @@ function hide {
         if [[ -n "$SECRETS_GPG_ARMOR" ]] &&
            [[ "$SECRETS_GPG_ARMOR" -ne 0 ]]; then
           args+=( '--armor' )
+        fi
+
+        if [[ -n "$_SECRETS_VERBOSE" ]]; then
+            args+=( '--no-permission-warning' )
         fi
 
         # we depend on $recipients being split on whitespace

--- a/src/commands/git_secret_init.sh
+++ b/src/commands/git_secret_init.sh
@@ -71,6 +71,7 @@ function init {
   # Create internal files:
 
   mkdir "$git_secret_dir" "$(_get_secrets_dir_keys)" "$(_get_secrets_dir_path)"
+  chmod 700 "$(_get_secrets_dir_keys)"  # for #811, set to rwx------
   touch "$(_get_secrets_dir_paths_mapping)"
 
   _message "init created: '$git_secret_dir/'"

--- a/src/commands/git_secret_removeperson.sh
+++ b/src/commands/git_secret_removeperson.sh
@@ -30,7 +30,7 @@ function removeperson {
 
   _assert_keyring_contains_emails_at_least_once "$secrets_dir_keys" "git-secret keyring" "${emails[@]}"
 
-  local args=( --homedir "$secrets_dir_keys" --no-permission-warning --batch --yes )
+  local args=( --homedir "$secrets_dir_keys" --batch --yes )
   if [[ -n "$_SECRETS_VERBOSE" ]]; then
     args+=( '--no-permission-warning' )
   fi

--- a/src/commands/git_secret_removeperson.sh
+++ b/src/commands/git_secret_removeperson.sh
@@ -37,7 +37,7 @@ function removeperson {
 
   for email in "${emails[@]}"; do
     # see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-
-    $SECRETS_GPG_COMMAND "${args[@]}" "$email" 3>&-
+    $SECRETS_GPG_COMMAND "${args[@]}" --delete-key "$email" 3>&-
     local exit_code=$?
     if [[ "$exit_code" -ne 0 ]]; then
       _abort "problem deleting key for '$email' with gpg: exit code $exit_code"

--- a/src/commands/git_secret_removeperson.sh
+++ b/src/commands/git_secret_removeperson.sh
@@ -30,9 +30,14 @@ function removeperson {
 
   _assert_keyring_contains_emails_at_least_once "$secrets_dir_keys" "git-secret keyring" "${emails[@]}"
 
+  local args=( --homedir "$secrets_dir_keys" --no-permission-warning --batch --yes )
+  if [[ -n "$_SECRETS_VERBOSE" ]]; then
+    args+=( '--no-permission-warning' )
+  fi
+
   for email in "${emails[@]}"; do
     # see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-
-    $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --batch --yes --delete-key "$email" 3>&-
+    $SECRETS_GPG_COMMAND "${args[@]}" "$email" 3>&-
     local exit_code=$?
     if [[ "$exit_code" -ne 0 ]]; then
       _abort "problem deleting key for '$email' with gpg: exit code $exit_code"

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -104,7 +104,7 @@ function tell {
     if [[ -z "$_SECRETS_VERBOSE" ]]; then
       $SECRETS_GPG_COMMAND "${args[@]}" > /dev/null 2>&1 3>&-
     else
-      $SECRETS_GPG_COMMAND --no-permission-warning "${args[@]}" 3>&-
+      $SECRETS_GPG_COMMAND "${args[@]}" 3>&-
     fi
     exit_code=$?
 

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -100,11 +100,11 @@ function tell {
     fi
 
     # Importing public key to the local keyring:
-    local args=( --homedir "$secrets_dir_keys" --no-permission-warning --import "$keyfile" )
+    local args=( --homedir "$secrets_dir_keys" --import "$keyfile" )
     if [[ -z "$_SECRETS_VERBOSE" ]]; then
       $SECRETS_GPG_COMMAND "${args[@]}" > /dev/null 2>&1 3>&-
     else
-      $SECRETS_GPG_COMMAND "${args[@]}" 3>&-
+      $SECRETS_GPG_COMMAND --no-permission-warning "${args[@]}" 3>&-
     fi
     exit_code=$?
 

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -254,7 +254,7 @@ function set_state_initial {
 function set_state_git {
   local has_initial_branch_option
   has_initial_branch_option=$(is_git_version_ge_2_28_0) # 0 for true
-  if [ "$(has_initial_branch_option)" eq 0 ]; then
+  if [[ "$has_initial_branch_option" == 0 ]]; then
     git init --initial-branch=main >> "$TEST_OUTPUT_FILE" 2>&1
   else
     git init >> "$TEST_OUTPUT_FILE" 2>&1

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -252,7 +252,7 @@ function set_state_initial {
 
 
 function set_state_git {
-  if [ "$(is_git_version_ge_2_28_0)" eq 1 ]; then
+  if [ "$(is_git_version_ge_2_28_0)" eq 0 ]; then
     git init --initial-branch=main >> "$TEST_OUTPUT_FILE" 2>&1
   else
     git init >> "$TEST_OUTPUT_FILE" 2>&1

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -37,15 +37,15 @@ BEGIN { OFS=":"; FS=":"; }
 '
 
 # git >= 2.28.0 supports --initial-branch=main
-function is_git_version_ge_2_28_0() { # based on code from github autopilot
+function is_git_version_ge_2_28_0 { # based on code from github autopilot
     local git_version=$(git --version | awk '{print $3}')
     local git_version_major=$(echo $git_version | awk -F. '{print $1}')
     local git_version_minor=$(echo $git_version | awk -F. '{print $2}')
     local git_version_patch=$(echo $git_version | awk -F. '{print $3}')
     if [[ $git_version_major -ge 2 ]] && [[ $git_version_minor -ge 28 ]] && [[ $git_version_patch -ge 0 ]]; then
-        return 0
+        echo 0
     else
-        return 1
+        echo 1
     fi
 }
 
@@ -252,7 +252,9 @@ function set_state_initial {
 
 
 function set_state_git {
-  if [ "$(is_git_version_ge_2_28_0)" eq 0 ]; then
+  local has_initial_branch_option
+  has_initial_branch_option=$(is_git_version_ge_2_28_0) # 0 for true
+  if [ "$(has_initial_branch_option)" eq 0 ]; then
     git init --initial-branch=main >> "$TEST_OUTPUT_FILE" 2>&1
   else
     git init >> "$TEST_OUTPUT_FILE" 2>&1

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -36,6 +36,19 @@ BEGIN { OFS=":"; FS=":"; }
 }
 '
 
+# git >= 2.28.0 supports --initial-branch=main
+function is_git_version_ge_2_28_0() { # based on code from github autopilot
+    local git_version=$(git --version | awk '{print $3}')
+    local git_version_major=$(echo $git_version | awk -F. '{print $1}')
+    local git_version_minor=$(echo $git_version | awk -F. '{print $2}')
+    local git_version_patch=$(echo $git_version | awk -F. '{print $3}')
+    if [[ $git_version_major -ge 2 ]] && [[ $git_version_minor -ge 28 ]] && [[ $git_version_patch -ge 0 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # GPG-based stuff:
 : "${SECRETS_GPG_COMMAND:='gpg'}"
 
@@ -239,7 +252,11 @@ function set_state_initial {
 
 
 function set_state_git {
-  git init >> "$TEST_OUTPUT_FILE" 2>&1
+  if [ $(is_git_version_ge_2_28_0) eq 1 ]; then
+    git init --initial-branch=main >> "$TEST_OUTPUT_FILE" 2>&1
+  else
+    git init >> "$TEST_OUTPUT_FILE" 2>&1
+  fi
 }
 
 

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -38,11 +38,15 @@ BEGIN { OFS=":"; FS=":"; }
 
 # git >= 2.28.0 supports --initial-branch=main
 function is_git_version_ge_2_28_0 { # based on code from github autopilot
+    # shellcheck disable=SC2155
     local git_version=$(git --version | awk '{print $3}')
-    local git_version_major=$(echo $git_version | awk -F. '{print $1}')
-    local git_version_minor=$(echo $git_version | awk -F. '{print $2}')
-    local git_version_patch=$(echo $git_version | awk -F. '{print $3}')
-    if [[ $git_version_major -ge 2 ]] && [[ $git_version_minor -ge 28 ]] && [[ $git_version_patch -ge 0 ]]; then
+    # shellcheck disable=SC2155
+    local git_version_major=$(echo "$git_version" | awk -F. '{print $1}')
+    # shellcheck disable=SC2155
+    local git_version_minor=$(echo "$git_version" | awk -F. '{print $2}')
+    # shellcheck disable=SC2155
+    local git_version_patch=$(echo "$git_version" | awk -F. '{print $3}')
+    if [[ "$git_version_major" -ge 2 ]] && [[ "$git_version_minor" -ge 28 ]] && [[ "$git_version_patch" -ge 0 ]]; then
         echo 0
     else
         echo 1

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -252,7 +252,7 @@ function set_state_initial {
 
 
 function set_state_git {
-  if [ $(is_git_version_ge_2_28_0) eq 1 ]; then
+  if [ "$(is_git_version_ge_2_28_0)" eq 1 ]; then
     git init --initial-branch=main >> "$TEST_OUTPUT_FILE" 2>&1
   else
     git init >> "$TEST_OUTPUT_FILE" 2>&1

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -184,7 +184,8 @@ function teardown {
   [ "$status" -eq 0 ]
   # git secret hide -m: uses temp file so cleaning should take place,
   # but we only show tmp file cleanup in VERBOSE mode
-  [ "${lines[0]}" = "git-secret: done. 1 of 1 files are hidden." ]
+  #[ "${lines[0]}" = "git-secret: done. 1 of 1 files are hidden." ]
+  [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # New files should be created:
   [ -f "$(_get_encrypted_filename "$FILE_TO_HIDE")" ]
@@ -202,7 +203,8 @@ function teardown {
   [ "$status" -eq 0 ]
   # git secret hide -m: uses temp file so cleaning should take place,
   # but we only show tmp file cleanup in VERBOSE mode
-  [[ "${lines[0]}" == *"git-secret: done. 1 of 1 files are hidden."* ]]
+  #[[ "${lines[0]}" == *"git-secret: done. 1 of 1 files are hidden."* ]]
+  [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # back path mappings
   cp "${path_mappings}" "${path_mappings}.bak"
@@ -234,7 +236,8 @@ function teardown {
   [ "$status" -eq 0 ]
   # git secret hide -m: uses temp file so cleaning should take place,
   # but we only show tmp file cleanup in VERBOSE mode
-  [[ "${lines[0]}" == *"git-secret: done. 1 of 1 files are hidden."* ]]
+  #[[ "${lines[0]}" == *"git-secret: done. 1 of 1 files are hidden."* ]]
+  [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # back path mappings
   cp "${path_mappings}" "${path_mappings}.bak"

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -184,7 +184,6 @@ function teardown {
   [ "$status" -eq 0 ]
   # git secret hide -m: uses temp file so cleaning should take place,
   # but we only show tmp file cleanup in VERBOSE mode
-  #[ "${lines[0]}" = "git-secret: done. 1 of 1 files are hidden." ]
   [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # New files should be created:
@@ -203,7 +202,6 @@ function teardown {
   [ "$status" -eq 0 ]
   # git secret hide -m: uses temp file so cleaning should take place,
   # but we only show tmp file cleanup in VERBOSE mode
-  #[[ "${lines[0]}" == *"git-secret: done. 1 of 1 files are hidden."* ]]
   [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # back path mappings
@@ -236,7 +234,6 @@ function teardown {
   [ "$status" -eq 0 ]
   # git secret hide -m: uses temp file so cleaning should take place,
   # but we only show tmp file cleanup in VERBOSE mode
-  #[[ "${lines[0]}" == *"git-secret: done. 1 of 1 files are hidden."* ]]
   [[ "$output" == *"git-secret: done. 1 of 1 files are hidden."* ]]
 
   # back path mappings


### PR DESCRIPTION
Closes #811 

may relate to #806 

@sobolevn : Maybe we should just not use `--no-permission-warnings` in these cases at all, (even when in non-verbose mode).