### PR TITLE
add freebsd testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v3
-    - name: Test in FreeBSD
+    - name: Run checks
       id: test
       uses: vmactions/freebsd-vm@v0.1.6
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: vmactions/freebsd-vm@v0.1.6
       with:
         usesh: true
-        prepare: pkg install -y gnupg bash
+        prepare: pkg install -y gnupg bash gmake
         run: |
           which -a bash
           which -a shell

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
         usesh: true
         prepare: pkg install -y gnupg bash
         run: |
+          which -a bash
+          which -a shell
           make test
 
   windows-wsl-ci:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: vmactions/freebsd-vm@v0.1.6
       with:
         usesh: true
-        prepare: pkg install -y gnupg make 
+        prepare: pkg install -y gnupg 
         run: |
           make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,19 @@ jobs:
     - name: Run checks
       run: SECRETS_TEST_VERBOSE=${{ matrix.test-verbose }} make test
 
+  freebsd-ci:
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test in FreeBSD
+      id: test
+      uses: vmactions/freebsd-vm@v0.1.6
+      with:
+        usesh: true
+        prepare: pkg install -y gnupg make 
+      run: |
+        make test
+
   windows-wsl-ci:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: vmactions/freebsd-vm@v0.1.6
       with:
         usesh: true
-        prepare: pkg install -y gnupg bash gmake git
+        prepare: pkg install -y gnupg bash gmake git gawk
         run: |
           which -a bash
           which -a shell

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,8 @@ jobs:
       with:
         usesh: true
         prepare: pkg install -y gnupg make 
-      run: |
-        make test
+        run: |
+          make test
 
   windows-wsl-ci:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: vmactions/freebsd-vm@v0.1.6
       with:
         usesh: true
-        prepare: pkg install -y gnupg 
+        prepare: pkg install -y gnupg bash
         run: |
           make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           which -a bash
           which -a shell
-          make test
+          gmake test
 
   windows-wsl-ci:
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: vmactions/freebsd-vm@v0.1.6
       with:
         usesh: true
-        prepare: pkg install -y gnupg bash gmake
+        prepare: pkg install -y gnupg bash gmake git
         run: |
           which -a bash
           which -a shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adds `SECRETS_GPG_ARMOR` env variable to use `gpg --armor`
   when encrypting files, so secret files are stored
   in text format rather than binary (#631)
+- Allow gnupg permission warnings in `tell`, `hide`, `reveal`, and `removeperson` (#811)
 - `git secret init` now sets `.gitsecret/keys` permission to 0700 (#811)
 - Improve verbose and non-verbose output
 
@@ -20,14 +21,14 @@
 
 ### Misc
 
-- Allow gnupg permission warnings in `tell`, `hide`, `reveal`, and `removeperson` (#811)
 - Rename `killperson` command to `removeperson` (#684)
 - Improve error messaging decrypting nonexistent files (#706)
 - Improve, expand, correct, and update docs (#699)
 - Update docs for use with CI/CD server (#675)
 - Upgrade bats-core to v1.6.0 (#755)
 - Test, and build RPMS, with Rocky and Alma Linux instead of CentOS (#765)
-- Test code on windows using WSL (#846)
+- Automate testing code on windows using WSL (#846)
+- Automate testing code on FreeBSD (#455)
 - Improve testing of .gitignore contents (#792)
 - Automate running verbose tests with SECRETS_TEST_VERBOSE=1 (#794)
 - Improve documentation about installing on Windows (#843)


### PR DESCRIPTION
Closes #455 
based on FreeBSD output from this PR, there were originally at least two issues:

* FreeBSD seems to install `bash` in /usr/local/bin, which is not in the PATH
* the `shell echo` and `${SHELL}` constructs we use heavily in the `test:` target of the `Makefile` seem not to operate as expected

It seemed both above issues were resolved by using `gmake`.

~If someone can contribute to moving this PR towards succeeding testing on FreeBSD that would be welcome~