### PR TITLE
Filter out revoked keys when enumerating keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Improve testing of .gitignore contents (#792)
 - Automate running verbose tests with SECRETS_TEST_VERBOSE=1 (#794)
 - Improve documentation about installing on Windows (#843)
-
+- Skip revoked keys when enumerating (#857)
 
 ## 0.4.0
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -701,7 +701,7 @@ function _get_users_in_gpg_keyring {
   ## We use --fixed-list-mode so older versions of gpg emit 'uid:' lines.
   ## Gawk splits on colon as --with-colon, matches field 1 as 'uid',
   result=$($SECRETS_GPG_COMMAND "${args[@]}" --no-permission-warning --list-public-keys --with-colon --fixed-list-mode | \
-      gawk -F: '$1=="uid"' )
+      gawk -F: '$1=="uid"&&$2!="r"' )
 
   local emails
   emails=$(_extract_emails_from_gpg_output "$result")


### PR DESCRIPTION
Adds '&&$2!="r"' to the gawk call to filter out revoked keys. Fixes https://github.com/sobolevn/git-secret/issues/857.

<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .md file(s) in man/man*/ to document your changes if appropriate
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Matches the second field in the key listing and filters out keys that are revoked.

Does this close any currently open issues?
------------------------------------------
https://github.com/sobolevn/git-secret/issues/857