### PR TITLE
fix links to bats docs about descriptor 3

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -571,7 +571,8 @@ function _user_required {
   local secrets_dir_keys
   secrets_dir_keys=$(_get_secrets_dir_keys)
 
-  # see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-
+  # for info about 3>&-
+  # see https://github.com/bats-core/bats-core/blob/master/docs/source/writing-tests.md#file-descriptor-3-read-this-if-bats-hangs 
   local keys_exist
   keys_exist=$($SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning -n --list-keys 3>&-)
   local exit_code=$?
@@ -602,7 +603,7 @@ function _get_user_key_expiry {
   local secrets_dir_keys
   secrets_dir_keys=$(_get_secrets_dir_keys)
 
-  # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs
+  # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core/blob/master/docs/source/writing-tests.md#file-descriptor-3-read-this-if-bats-hangs
   line=$($SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --list-public-keys --with-colon --fixed-list-mode "$username" | grep ^pub: 3>&-)
 
   local expiry_epoch
@@ -729,7 +730,7 @@ function _extract_emails_from_gpg_output {
   # gensub() outputs email from <> within field 10, "User-ID".  If there's no <>, then field is just an email address
   #  (and maybe a comment) and we pass it through.
   # Sed at the end removes any 'comment' that appears in parentheses, for #530
-  # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs
+  # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core/blob/master/docs/source/writing-tests.md#file-descriptor-3-read-this-if-bats-hangs
   local emails
   emails=$(echo "$result" | gawk -F: '{print gensub(/.*<(.*)>.*/, "\\1", "g", $10); }' | sed 's/([^)]*)//g' 3>&-)
   echo "$emails"

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -181,7 +181,7 @@ function hide {
         set +e  # disable 'set -e' so we can capture exit_code
 
      	  # For info about `3>&-` see:
-        # https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs
+        # https://github.com/bats-core/bats-core/blob/master/docs/source/writing-tests.md#file-descriptor-3-read-this-if-bats-hangs
         local gpg_output
         gpg_output=$($SECRETS_GPG_COMMAND "${args[@]}" 3>&-)  # we leave stderr alone
         local exit_code=$?

--- a/src/commands/git_secret_removeperson.sh
+++ b/src/commands/git_secret_removeperson.sh
@@ -34,7 +34,7 @@ function removeperson {
   # we no longer use --no-permission-warning here in non-verbose mode, for #811
 
   for email in "${emails[@]}"; do
-    # see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-
+    # see https://github.com/bats-core/bats-core/blob/master/docs/source/writing-tests.md#file-descriptor-3-read-this-if-bats-hangs for info about 3>&-
     $SECRETS_GPG_COMMAND "${args[@]}" --delete-key "$email" 3>&-
     local exit_code=$?
     if [[ "$exit_code" -ne 0 ]]; then

--- a/src/commands/git_secret_tell.sh
+++ b/src/commands/git_secret_tell.sh
@@ -10,7 +10,7 @@ END { print cnt }
 function get_gpg_key_count {
   local secrets_dir_keys
   secrets_dir_keys=$(_get_secrets_dir_keys)
-  # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs
+  # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core/blob/master/docs/source/writing-tests.md#file-descriptor-3-read-this-if-bats-hangs
   $SECRETS_GPG_COMMAND --homedir "$secrets_dir_keys" --no-permission-warning --list-public-keys --with-colon | gawk "$AWK_GPG_KEY_CNT" 3>&-
   local exit_code=$?
   if [[ "$exit_code" -ne 0 ]]; then
@@ -80,7 +80,7 @@ function tell {
     # shellcheck disable=SC2154
     local keyfile="$temporary_filename"
 
-    # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs
+    # 3>&- closes fd 3 for bats, see https://github.com/bats-core/bats-core/blob/master/docs/source/writing-tests.md#file-descriptor-3-read-this-if-bats-hangs
     local exit_code
     if [[ -z "$homedir" ]]; then
       $SECRETS_GPG_COMMAND --export -a "$email" > "$keyfile" 3>&-


### PR DESCRIPTION
fixes links in comments to bats docs about file descriptor 3