### PR TITLE
bug fix for 'reveal' in a subdir (#903)

### DIFF
--- a/src/commands/git_secret_reveal.sh
+++ b/src/commands/git_secret_reveal.sh
@@ -44,8 +44,10 @@ function reveal {
 
   local counter=0
   local to_show=( "$@" )
+  local path_prepend_func='_prepend_relative_root_path'
 
   if [ ${#to_show[@]} -eq 0 ]; then
+    path_prepend_func='_prepend_root_path'
     while read -r record; do
       to_show+=("$record")  # add record to array
     done < "$path_mappings"
@@ -55,7 +57,7 @@ function reveal {
     local filename
     local path
     filename=$(_get_record_filename "$line")
-    path=$(_prepend_relative_root_path "$filename")  # this uses the _relative version because of #710
+    path=$("$path_prepend_func" "$filename")
 
     if [[ "$filename" == *"$SECRETS_EXTENSION" ]]; then
       _abort "cannot decrypt to secret version of file: $filename"

--- a/tests/test_reveal.bats
+++ b/tests/test_reveal.bats
@@ -293,3 +293,25 @@ function teardown {
   # clean up
   rm -rf subdir
 }
+
+@test "run 'reveal' for all files from subdir" {
+  local password
+  password=$(test_user_password "$TEST_DEFAULT_USER")
+
+  mkdir -p subdir
+  echo "content2" > subdir/new_filename.txt
+
+  ( # start subshell for subdir tests
+    cd subdir
+    run git secret add new_filename.txt
+    [ "$status" -eq 0 ]
+    run git secret hide
+    [ "$status" -eq 0 ]
+  
+    run git secret reveal -d "$TEST_GPG_HOMEDIR" -p "$password"
+    [ "$status" -eq 0 ]
+  ) # end subshell
+
+  # clean up
+  rm -rf subdir
+}


### PR DESCRIPTION
resolve #903 

I've made a bug patch for `reveal` command and added a test case for covering the case.
