### PR TITLE
avoid pacman signing error on arch

### DIFF
--- a/.ci/docker-ci/arch/Dockerfile
+++ b/.ci/docker-ci/arch/Dockerfile
@@ -3,7 +3,7 @@ FROM archlinux:base-20220529.0.58327
 LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="git-secret team"
 
-RUN pacman -Sy archlinux-keyring \
+RUN pacman -Sy --noconfirm archlinux-keyring \
   && pacman -Syu --needed --noconfirm \
   # Direct dependencies:
   bash \

--- a/.ci/docker-ci/arch/Dockerfile
+++ b/.ci/docker-ci/arch/Dockerfile
@@ -3,7 +3,7 @@ FROM archlinux:base-20220529.0.58327
 LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="git-secret team"
 
-RUN pacman -Sy archlinux-keyring && pacman -Su && \
+RUN pacman -Sy archlinux-keyring && pacman -Syu && \
   pacman -Syu --needed --noconfirm \
   # Direct dependencies:
   bash \

--- a/.ci/docker-ci/arch/Dockerfile
+++ b/.ci/docker-ci/arch/Dockerfile
@@ -3,7 +3,8 @@ FROM archlinux:base-20220529.0.58327
 LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="git-secret team"
 
-RUN pacman -Sy --noconfirm archlinux-keyring \
+RUN pacman-key --init \
+  && pacman -Sy --noconfirm archlinux-keyring \
   && pacman -Su \
   && pacman -Syu --needed --noconfirm \
   # Direct dependencies:

--- a/.ci/docker-ci/arch/Dockerfile
+++ b/.ci/docker-ci/arch/Dockerfile
@@ -3,8 +3,8 @@ FROM archlinux:base-20220529.0.58327
 LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="git-secret team"
 
-RUN pacman -Sy archlinux-keyring && pacman -Syu && \
-  pacman -Syu --needed --noconfirm \
+RUN pacman -Syu --needed --noconfirm \
+  archlinux-keyring \
   # Direct dependencies:
   bash \
   gawk \

--- a/.ci/docker-ci/arch/Dockerfile
+++ b/.ci/docker-ci/arch/Dockerfile
@@ -3,8 +3,8 @@ FROM archlinux:base-20220529.0.58327
 LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="git-secret team"
 
-RUN pacman -Syu --needed --noconfirm \
-  archlinux-keyring \
+RUN pacman -Sy archlinux-keyring \
+  && pacman -Syu --needed --noconfirm \
   # Direct dependencies:
   bash \
   gawk \

--- a/.ci/docker-ci/arch/Dockerfile
+++ b/.ci/docker-ci/arch/Dockerfile
@@ -4,12 +4,13 @@ LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="git-secret team"
 
 RUN pacman -Sy --noconfirm archlinux-keyring \
+  && pacman -Su \
   && pacman -Syu --needed --noconfirm \
   # Direct dependencies:
   bash \
   gawk \
   git \
-  gnupg \
+  #gnupg \
   # Assumed to be present:
   diffutils \
   file \

--- a/.ci/docker-ci/arch/Dockerfile
+++ b/.ci/docker-ci/arch/Dockerfile
@@ -3,7 +3,8 @@ FROM archlinux:base-20220529.0.58327
 LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="git-secret team"
 
-RUN pacman -Syu --needed --noconfirm \
+RUN pacman -Sy archlinux-keyring && pacman -Su && \
+  pacman -Syu --needed --noconfirm \
   # Direct dependencies:
   bash \
   gawk \


### PR DESCRIPTION
For #916 

pacman was complaining
"libcap-2.65-1-x86_64.pkg.tar.zst is corrupted"
 See https://github.com/sobolevn/git-secret/runs/7564903813?check_suite_focus=true