### PR TITLE
test with spaces in the parent directory

### DIFF
--- a/.ci/docker-ci/alpine/Dockerfile
+++ b/.ci/docker-ci/alpine/Dockerfile
@@ -14,4 +14,5 @@ RUN apk add --no-cache --update \
   # Assumed to be present:
   file \
   make \
-  procps
+  procps \
+  perl

--- a/.ci/docker-ci/alpine/Dockerfile
+++ b/.ci/docker-ci/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.1
+FROM alpine:3.16.2
 
 LABEL maintainer="mail@sobolevn.me"
 LABEL vendor="git-secret team"
@@ -14,5 +14,4 @@ RUN apk add --no-cache --update \
   # Assumed to be present:
   file \
   make \
-  procps \
-  perl
+  procps 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         docker-env:
           - alma
-          #- alpine         # temporarily disable this test
+          - alpine
           #- arch           # we can't get this to pass as of 2022-09-05
           - debian-gnupg1  # We need to test legacy version of gnupg
           - debian-gnupg2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         docker-env:
           - alma
           - alpine
-          - arch
+          #- arch           # we can't get this to pass as of 2022-09-05
           - debian-gnupg1  # We need to test legacy version of gnupg
           - debian-gnupg2
           - fedora

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         docker-env:
           - alma
-          - alpine
+          #- alpine         # temporarily disable this test
           #- arch           # we can't get this to pass as of 2022-09-05
           - debian-gnupg1  # We need to test legacy version of gnupg
           - debian-gnupg2

--- a/tests/test_for_perl.bats
+++ b/tests/test_for_perl.bats
@@ -6,8 +6,11 @@ load _test_base
 
 @test "test for perl binary" {
 
-  perl -v           # show output
-  command -v perl # show output
+  perl -v           
+  # show output
+  
+  command -v perl 
+  # show output
 
   #run command -v perl
   #[ "$status" -eq 0 ]

--- a/tests/test_for_perl.bats
+++ b/tests/test_for_perl.bats
@@ -18,7 +18,7 @@ function teardown {
 
   local perl_test_file="perl-v-output"
 
-  perl -v > "$perl_test_file"
-  
+  perl -v > "$perl_test_file"       # output of perl -v
+  bats_diag_file "$perl_test_file"  # show the contents as diagnostic output
 }
 

--- a/tests/test_for_perl.bats
+++ b/tests/test_for_perl.bats
@@ -6,8 +6,8 @@ load _test_base
 
 @test "test for perl binary" {
 
-  #run which perl
-  #[ "$status" -eq 0 ]
+  run command -v perl
+  [ "$status" -eq 0 ]
 
   local perl_test_file="perl-v-output"
 

--- a/tests/test_for_perl.bats
+++ b/tests/test_for_perl.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+load _test_base
+
+
+function setup {
+}
+
+
+function teardown {
+}
+
+
+@test "run 'add' normally" {
+
+  run which perl
+  [ "$status" -ne 0 ]
+
+  local perl_test_file="perl-v-output"
+
+  perl -v > "$perl_test_file"
+  
+}
+

--- a/tests/test_for_perl.bats
+++ b/tests/test_for_perl.bats
@@ -6,8 +6,11 @@ load _test_base
 
 @test "test for perl binary" {
 
-  run command -v perl
-  [ "$status" -eq 0 ]
+  perl -v           # show output
+  command -v perl # show output
+
+  #run command -v perl
+  #[ "$status" -eq 0 ]
 
   local perl_test_file="perl-v-output"
 

--- a/tests/test_for_perl.bats
+++ b/tests/test_for_perl.bats
@@ -3,18 +3,11 @@
 load _test_base
 
 
-function setup {
-}
 
-
-function teardown {
-}
-
-
-@test "run 'add' normally" {
+@test "test for perl binary" {
 
   run which perl
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 0 ]
 
   local perl_test_file="perl-v-output"
 

--- a/tests/test_for_perl.bats
+++ b/tests/test_for_perl.bats
@@ -6,8 +6,8 @@ load _test_base
 
 @test "test for perl binary" {
 
-  run which perl
-  [ "$status" -eq 0 ]
+  #run which perl
+  #[ "$status" -eq 0 ]
 
   local perl_test_file="perl-v-output"
 

--- a/utils/tests.sh
+++ b/utils/tests.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-#TEST_DIR=/tmp/git-secret-test
-TEST_DIR="/tmp/git secret test"
+TEST_DIR=/tmp/git-secret-test
+#TEST_DIR="/tmp/git secret test"    # this breaks tests badly
 
 rm -rf "${TEST_DIR}"
 mkdir "${TEST_DIR}"
@@ -26,7 +26,8 @@ chmod 0700 "${TEST_DIR}"
     # bats expects diagnostic lines to be sent to fd 3, matching regex '^# '
     #  (IE, like: `echo '# message here' >&3`).
     # bats ... 3>&1 shows diagnostic output
-    bats "${SECRETS_PROJECT_ROOT}/tests" 3>&1
+    #bats "${SECRETS_PROJECT_ROOT}/tests" 3>&1
+    bats "${SECRETS_PROJECT_ROOT}/tests/test_for_perl.bats" 3>&1
 )
 
 rm -rf "${TEST_DIR}"

--- a/utils/tests.sh
+++ b/utils/tests.sh
@@ -4,7 +4,8 @@
 
 set -e
 
-TEST_DIR=/tmp/git-secret-test
+#TEST_DIR=/tmp/git-secret-test
+TEST_DIR="/tmp/git secret test"
 
 rm -rf "${TEST_DIR}"
 mkdir "${TEST_DIR}"


### PR DESCRIPTION
WIP for #135 
Currently just shows problem
* analysis shows error is happening in `gitignore_add_pattern`'s call to `_gawk_inplace` when running `git-secret-init`
* This is output from `bash -x` on `git-secret-init` in directory with spaces, showing problem:

````
(... LOTS REMOVED ...)
++ gawk -v 'RS='\''' -v 'FS='\''' 'END{ gsub(/^\s+/,""); print $1 }'
'\'' /home/examp/tmp/gitsec test/.gitignore'
+ dest_file='/home/examp/tmp/gitsec test/.gitignore'
+ _temporary_file
++ _os_based __temp_file
++ case "$(uname -s)" in
+++ uname -s
++ __temp_file_linux
++ local filename
+++ mktemp -p /tmp _git_secret.XXXXXX
++ filename=/tmp/_git_secret.RLgKjh
++ echo /tmp/_git_secret.RLgKjh
+ temporary_filename=/tmp/_git_secret.RLgKjh
+ trap 'if [[ -f "$temporary_filename" ]]; then if [[ -n "$_SECRETS_VERBOSE" ]] || [[ -n "$SECRETS_TEST_VERBOSE" ]]; then echo "git-secret: cleaning up: $temporary_filename"; fi; rm -f "$temporary_filename"; fi;' EXIT
+ bash -c 'gawk -v pattern=.gitsecret/keys/random_seed '\''
BEGIN {
  cnt=0
}

function check_print_line(line){
  if (line == pattern) {
    cnt++
  }
  print line
}

# main function
{
  check_print_line($0)      # check and print first line
  while (getline == 1) {    # check and print all other
    check_print_line($0)
  }
}

END {
  if ( cnt == 0) {         # if file did not contain pattern add
    print pattern
  }
}
'\'' /home/examp/tmp/gitsec test/.gitignore'
gawk: cmd. line:3: fatal: cannot open file `/home/examp/tmp/gitsec' for reading (No such file or directory)
+ [[ -f /tmp/_git_secret.RLgKjh ]]
+ [[ -n '' ]]
+ [[ -n '' ]]
+ rm -f /tmp/_git_secret.RLgKjh

````
