### PR TITLE
fix for #918, which picked up gnu stat from brew

### DIFF
--- a/src/_utils/_git_secret_tools_osx.sh
+++ b/src/_utils/_git_secret_tools_osx.sh
@@ -32,7 +32,8 @@ function __get_octal_perms_osx {
   local filename
   filename=$1
   local perms
-  perms=$(stat -f "%04OLp" "$filename")
+  # we use /usr/bin/stat in case there's another stat available from brew. See #918
+  perms=$(/usr/bin/stat -f "%04OLp" "$filename")
   # see _git_secret_tools_freebsd.sh for more about stat's format string
   echo "$perms"
 }


### PR DESCRIPTION
closes #918 