### PR TITLE
Ignore exact 

### DIFF
--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -304,6 +304,12 @@ function _git_normalize_filename {
 
   local result
   result=$(git ls-files --full-name -o "$filename")
+
+  # if file is in the top level, append a / so only that top level file is considered
+  if [[ $filename != *"/"* ]]; then
+    result="/$result"
+  fi
+
   echo "$result"
 }
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -319,16 +319,6 @@ function _git_normalize_filename {
 }
 
 
-function _git_normalize_filename2 {
-  local filename="$1" # required
-
-  local result
-  result=$(git ls-files --full-name -o "$filename")
-
-  echo "$result"
-}
-
-
 function _maybe_create_gitignore {
   # This function creates '.gitignore' if it was missing.
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -222,6 +222,11 @@ function _get_record_filename {
   local filename
   filename=$(echo "$record" | awk -F: '{print $1}')
 
+  # remove / in top level file
+  if [[ $filename == "/"* ]]; then
+    filename="${filename:1}"
+  fi
+
   echo "$filename"
 }
 
@@ -309,6 +314,16 @@ function _git_normalize_filename {
   if [[ $filename != *"/"* ]]; then
     result="/$result"
   fi
+
+  echo "$result"
+}
+
+
+function _git_normalize_filename2 {
+  local filename="$1" # required
+
+  local result
+  result=$(git ls-files --full-name -o "$filename")
 
   echo "$result"
 }

--- a/tests/test_add.bats
+++ b/tests/test_add.bats
@@ -33,7 +33,7 @@ function teardown {
 
   local files_list
   files_list=$(cat "$path_mappings")
-  [ "$files_list" = "$filename" ]
+  [ "$files_list" = "/$filename" ]
 
   # Cleaning up:
   rm "$filename" ".gitignore"
@@ -70,7 +70,7 @@ function teardown {
   echo "content" > "$test_file"
 
   local quoted_name
-  quoted_name=$(printf '%q' "$test_file")
+  quoted_name=$(printf '%q' "/$test_file")
 
   # add -i is now a no-op (See #225) so this tests that -i does nothing.
   run git secret add -i "$test_file"
@@ -114,7 +114,7 @@ function teardown {
   [ "$status" -eq 0 ]
 
   [[ -f "$current_dir/.gitignore" ]]
-  run file_has_line "$nested_dir/$test_file" "$current_dir/.gitignore"
+  run file_has_line "/$nested_dir/$test_file" "$current_dir/.gitignore"
   [ "$output" = '0' ]
 
   # .gitignore was not created:
@@ -205,7 +205,7 @@ function teardown {
 
   local files_list
   files_list=$(cat "$path_mappings")
-  [ "$files_list" = "$filename" ]
+  [ "$files_list" = "/$filename" ]
 
   # Cleaning up:
   rm "$filename" ".gitignore"
@@ -268,7 +268,7 @@ function teardown {
 
   local files_list
   files_list=$(cat "$path_mappings")
-  [ "$files_list" = "$filename" ]
+  [ "$files_list" = "/$filename" ]
 
   # Ensuring the file is correctly git-ignored
   run git check-ignore "$filename"

--- a/tests/test_hide.bats
+++ b/tests/test_hide.bats
@@ -278,7 +278,7 @@ function teardown {
   [ "$status" -eq 0 ]
 
   # File must be removed:
-  [ ! -f "$FILE_TO_HIDE" ]
+  [ ! -f "/$FILE_TO_HIDE" ]
 }
 
 
@@ -287,7 +287,7 @@ function teardown {
   [ "$status" -eq 0 ]
 
   # File must be removed:
-  [ ! -f "$FILE_TO_HIDE" ]
+  [ ! -f "/$FILE_TO_HIDE" ]
 
   # It should be verbose:
   [[ "$output" == *"removing unencrypted files"* ]]
@@ -311,8 +311,8 @@ function teardown {
   [ "$status" -eq 0 ]
 
   # File must be removed:
-  [ ! -f "$FILE_TO_HIDE" ]
-  [ ! -f "$second_file" ]
+  [ ! -f "/$FILE_TO_HIDE" ]
+  [ ! -f "/$second_file" ]
 
   # It should be verbose:
   [[ "$output" == *"removing unencrypted files"* ]]


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .md file(s) in man/man*/ to document your changes if appropriate
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------

Currently, if a file is a top-level file within a repository and is added to git secret, the filename added to `.gitignore` will subsequently ignore all files with that name in further sub-directories.

This can cause some unintended behaviors if you are using git-secret in a mixed repository where there are both encrypted and unencrypted files as any file within sub-directories will be ignored. Adding files to both the `.gitignore` and `.git-secret/mapping.cfg` utilize [`git ls-files`](https://git-scm.com/docs/git-ls-files) to output the filename and then prepends the path to it in subsequent functions. To fix this issue, if a file is within the root directory (i.e., the path does not contain a `/`), I prepended a `/` to the filename so that git ignore works as intended. 


Does this close any currently open issues?
------------------------------------------
No

Steps to Reproduce
-------------------------------------
 _Current version: git-secret 0.5.0-alpha2_

1. Add a file within the root directory to git-secret
     1.  the file in both `.gitignore` and `git-secret` will be `FILENAME`
2. Commit the file
3. Add a file in a sub-directory with the _same_ name as in step 1. 
    1. _Result:_ file will be ignored - even if was intended to be added to git

Any other comments?
-------------------

While this can be fixed by editing the `.gitignore` whenever it causes conflict, this PR just stops the behavior from stopping it in the first place.
