### PR TITLE
Delmendo remove apt key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix `clean`, `hide`, `reveal` so they only remove marked secret files (#833)
 - Fix for `removeperson` if same email is present multiple times (#638)
 - Correct error message about files missing from .gitignore
+- Updated installation instructions for Debian/Ubuntu to remove deprecated apt-key
 
 ### Misc
 

--- a/utils/deb/install.sh
+++ b/utils/deb/install.sh
@@ -2,7 +2,7 @@ wget -qO - 'https://gitsecret.jfrog.io/artifactory/api/gpg/key/public' | gpg --d
 sudo apt-get install apt-transport-https  ca-certificates --yes
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/git-secret.gpg] https://gitsecret.jfrog.io/artifactory/git-secret-deb git-secret main" | sudo tee /etc/apt/sources.list.d/git-secret.list
 sudo apt-get update && sudo apt-get install -y git-secret
-sudo apt-get update && sudo apt-get install -y git-secret
+
 
 # Testing, that it worked:
 git secret --version

--- a/utils/deb/install.sh
+++ b/utils/deb/install.sh
@@ -1,5 +1,7 @@
-sudo sh -c "echo 'deb https://gitsecret.jfrog.io/artifactory/git-secret-deb git-secret main' >> /etc/apt/sources.list"
-wget -qO - 'https://gitsecret.jfrog.io/artifactory/api/gpg/key/public' | sudo apt-key add -
+wget -qO - 'https://gitsecret.jfrog.io/artifactory/api/gpg/key/public' | gpg --dearmor | sudo tee /usr/share/keyrings/git-secret.gpg > /dev/null
+sudo apt-get install apt-transport-https  ca-certificates --yes
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/git-secret.gpg] https://gitsecret.jfrog.io/artifactory/git-secret-deb git-secret main" | sudo tee /etc/apt/sources.list.d/git-secret.list
+sudo apt-get update && sudo apt-get install -y git-secret
 sudo apt-get update && sudo apt-get install -y git-secret
 
 # Testing, that it worked:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

Here's how it's done:
0. If you are planning a large feature, please, discuss it first in a separate issue.
   See also [CONTRIBUTING.md](https://github.com/sobolevn/git-secret/blob/master/CONTRIBUTING.md) if you haven't already.
1. Make sure that you open your pull request against the `master` branch
2. Make sure that your code has the same style as the surrounding code and git-secret in general
3. Make sure your code passes using `shellcheck` with `make lint`
4. You can also spell check your code using 'aspell -c {filename}'
5. If you are adding or changing features, please add tests that cover the new behavior (in addition to the unchanged behavior if appropriate)
6. Make sure that all tests pass
7. Change the .md file(s) in man/man*/ to document your changes if appropriate
   (regenerating man pages with 'make build-man' is optional)
8. Add an entry to CHANGELOG.md explaining the change briefly and, if appropriate, referring to the related issue #

Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
The Debian instructions use apt-key which has been deprecated. Using the existing directions causes a deprecation warning on every package update.  I re-wrote them to use the modern path - this removes the error and installs the pacakge.

Does this close any currently open issues?
------------------------------------------
…

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…
