### PR TITLE
Fix issue #135, allow whitespace in parent directories

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -11,7 +11,7 @@ POSTS_LOCATION='docs/_posts'
 
 
 function checkout_manuals {
-  cp -r man/ docs/man
+  cp -R man/ docs/man
 }
 
 

--- a/src/_utils/_git_secret_tools.sh
+++ b/src/_utils/_git_secret_tools.sh
@@ -202,13 +202,11 @@ function _temporary_file {
 
 
 function _gawk_inplace {
-  local parms="$*"
-  local dest_file
-  dest_file="$(echo "$parms" | gawk -v RS="'" -v FS="'" 'END{ gsub(/^\s+/,""); print $1 }')"
+  local dest_file="${!#}"  # last argument
 
   _temporary_file
 
-  bash -c "gawk ${parms}" > "$temporary_filename"
+  gawk "$@" > "$temporary_filename"
   mv "$temporary_filename" "$dest_file"
 }
 
@@ -253,7 +251,7 @@ function _fsdb_rm_record {
   local key="$1"  # required
   local fsdb="$2" # required
 
-  _gawk_inplace -v key="'$key'" "'$AWK_FSDB_RM_RECORD'" "$fsdb"
+  _gawk_inplace -v "key=$key" "$AWK_FSDB_RM_RECORD" "$fsdb"
 }
 
 
@@ -261,7 +259,7 @@ function _fsdb_clear_hashes {
   # First parameter is the path to fsdb
   local fsdb="$1" # required
 
-  _gawk_inplace "'$AWK_FSDB_CLEAR_HASHES'" "$fsdb"
+  _gawk_inplace "$AWK_FSDB_CLEAR_HASHES" "$fsdb"
 }
 
 

--- a/src/commands/git_secret_hide.sh
+++ b/src/commands/git_secret_hide.sh
@@ -64,7 +64,7 @@ function _fsdb_update_hash {
 
   fsdb=$(_get_secrets_dir_paths_mapping)
 
-  _gawk_inplace -v key="'$key'" -v hash="$hash" "'$AWK_FSDB_UPDATE_HASH'" "$fsdb"
+  _gawk_inplace -v "key=$key" -v "hash=$hash" "$AWK_FSDB_UPDATE_HASH" "$fsdb"
 }
 
 

--- a/src/commands/git_secret_init.sh
+++ b/src/commands/git_secret_init.sh
@@ -36,7 +36,7 @@ function gitignore_add_pattern {
   gitignore_file_path=$(_prepend_root_path '.gitignore')
 
   _maybe_create_gitignore
-  _gawk_inplace -v pattern="$pattern" "'$AWK_ADD_TO_GITIGNORE'" "$gitignore_file_path"
+  _gawk_inplace -v "pattern=$pattern" "$AWK_ADD_TO_GITIGNORE" "$gitignore_file_path"
 }
 
 function init {

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -166,7 +166,7 @@ function install_fixture_full_key {
   cp "$FIXTURES_DIR/gpg/${1}/private.key" "$private_key"
 
   if [[ "${GPG_VER_21:-0}" -eq 1 ]]; then
-    echo "$(test_user_password "$1")" | _gpgtest --allow-secret-key-import \
+    test_user_password "$1" | _gpgtest --allow-secret-key-import \
       --import "$private_key" >> "${TEST_OUTPUT_FILE}" 2>&1
   else
     _gpgtest --allow-secret-key-import \

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -56,8 +56,10 @@ function is_git_version_ge_2_28_0 { # based on code from github autopilot
 # GPG-based stuff:
 : "${SECRETS_GPG_COMMAND:='gpg'}"
 
-# This command is used with absolute homedir set and disabled warnings:
-GPGTEST="$SECRETS_GPG_COMMAND --homedir=$TEST_GPG_HOMEDIR --no-permission-warning --batch"
+# This function is used with absolute homedir set and disabled warnings:
+function _gpgtest {
+  "$SECRETS_GPG_COMMAND" --homedir "$TEST_GPG_HOMEDIR" --no-permission-warning --batch "$@"
+}
 
 # Test key fixture data. Fixtures are at tests/fixtures/gpg/$email
 
@@ -134,21 +136,11 @@ function stop_gpg_agent {
 }
 
 
-function get_gpgtest_prefix {
-  if [[ $GPG_VER_21 -eq 1  ]]; then
-    # shellcheck disable=SC2086
-    echo "echo \"$(test_user_password $1)\" | "
-  else
-    echo ''
-  fi
-}
-
-
 function get_gpg_fingerprint_by_email {
   local email="$1"
   local fingerprint
 
-  fingerprint=$($GPGTEST --with-fingerprint \
+  fingerprint=$(_gpgtest --with-fingerprint \
                          --with-colon \
                          --list-secret-key "$email" | gawk "$AWK_GPG_GET_FP")
   echo "$fingerprint"
@@ -159,16 +151,13 @@ function install_fixture_key {
   local public_key="$BATS_TMPDIR/public-${1}.key"
 
   cp "$FIXTURES_DIR/gpg/${1}/public.key" "$public_key"
-  $GPGTEST --import "$public_key" >> "$TEST_OUTPUT_FILE" 2>&1
+  _gpgtest --import "$public_key" >> "$TEST_OUTPUT_FILE" 2>&1
   rm -f "$public_key" || _abort "Couldn't delete public key: $public_key"
 }
 
 
 function install_fixture_full_key {
   local private_key="$BATS_TMPDIR/private-${1}.key"
-  local gpgtest_prefix
-  gpgtest_prefix=$(get_gpgtest_prefix "$1")
-  local gpgtest_import="$gpgtest_prefix $GPGTEST"
   local email
   local fingerprint
 
@@ -176,8 +165,13 @@ function install_fixture_full_key {
 
   cp "$FIXTURES_DIR/gpg/${1}/private.key" "$private_key"
 
-  bash -c "$gpgtest_import --allow-secret-key-import \
-    --import \"$private_key\"" >> "${TEST_OUTPUT_FILE}" 2>&1
+  if [[ "${GPG_VER_21:-0}" -eq 1 ]]; then
+    echo "$(test_user_password "$1")" | _gpgtest --allow-secret-key-import \
+      --import "$private_key" >> "${TEST_OUTPUT_FILE}" 2>&1
+  else
+    _gpgtest --allow-secret-key-import \
+      --import "$private_key" >> "${TEST_OUTPUT_FILE}" 2>&1
+  fi
 
   # since 0.1.2 fingerprint is returned:
   fingerprint=$(get_gpg_fingerprint_by_email "$email")
@@ -194,7 +188,7 @@ function uninstall_fixture_key {
   local email
 
   email="$1"
-  $GPGTEST --yes --delete-key "$email" >> "$TEST_OUTPUT_FILE" 2>&1
+  _gpgtest --yes --delete-key "$email" >> "$TEST_OUTPUT_FILE" 2>&1
 }
 
 
@@ -208,7 +202,7 @@ function uninstall_fixture_full_key {
     fingerprint=$(get_gpg_fingerprint_by_email "$email")
   fi
 
-  $GPGTEST --yes --delete-secret-keys "$fingerprint" >> "$TEST_OUTPUT_FILE" 2>&1
+  _gpgtest --yes --delete-secret-keys "$fingerprint" >> "$TEST_OUTPUT_FILE" 2>&1
 
   uninstall_fixture_key "$1"
 }

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -82,6 +82,41 @@ function teardown {
 }
 
 
+@test "run 'init' in directory with spaces in parent path" {
+  # This test covers this issue:
+  # https://github.com/sobolevn/git-secret/issues/135
+
+  if [[ "$BATS_RUNNING_FROM_GIT" -eq 1 ]]; then
+    skip "this test is skipped while 'git commit'. See #334"
+  fi
+
+  local test_dir="$BATS_TMPDIR/path with spaces"
+  local current_dir="$PWD"
+
+  mkdir -p "$test_dir"
+  cd "$test_dir"
+
+  local has_initial_branch_option
+  has_initial_branch_option=$(is_git_version_ge_2_28_0)
+  if [[ "$has_initial_branch_option" == 0 ]]; then
+    git init --initial-branch=main >> "$TEST_OUTPUT_FILE" 2>&1
+  else
+    git init >> "$TEST_OUTPUT_FILE" 2>&1
+  fi
+
+  run git secret init
+  [ "$status" -eq 0 ]
+
+  local secrets_dir
+  secrets_dir=$(_get_secrets_dir)
+  [[ -d "$secrets_dir" ]]
+
+  # Cleaning up:
+  cd "$current_dir"
+  rm -rf "$test_dir"
+}
+
+
 @test "run 'init' with '.gitsecret' already initialized" {
   local secrets_dir
   secrets_dir=$(_get_secrets_dir)

--- a/utils/tests.sh
+++ b/utils/tests.sh
@@ -4,10 +4,10 @@
 
 set -e
 
-TEST_DIR=/tmp/git-secret-test
+TEST_DIR="/tmp/git-secret-test/this dir has spaces"
 
 rm -rf "${TEST_DIR}"
-mkdir "${TEST_DIR}"
+mkdir -p "${TEST_DIR}"
 echo "# created dir: ${TEST_DIR}"
 
 chmod 0700 "${TEST_DIR}"


### PR DESCRIPTION
Change how we use gawk to support whitespace in parent folder names.
Run all tests in directory with spaces to show #135 is fixed.
Add an init test specifically to test for #135 regression.