### PR TITLE
fix wsl automated builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,8 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: Vampire/setup-wsl@v6
-      with: 
+      with:
+        distribution: Ubuntu-22.04
         update: 'true'
         additional-packages: gnupg make man git gawk file
     - run: git config --global core.autocrlf input


### PR DESCRIPTION
Use Ubuntu-22.04 to load WSL; supported through April 2027